### PR TITLE
Useing OmegaConf to convert checkpoint["cfg"] dict

### DIFF
--- a/examples/speech_recognition/w2l_decoder.py
+++ b/examples/speech_recognition/w2l_decoder.py
@@ -21,7 +21,7 @@ import torch
 from examples.speech_recognition.data.replabels import unpack_replabels
 from fairseq import tasks
 from fairseq.utils import apply_to_sample
-from omegaconf import open_dict
+from omegaconf import open_dict, OmegaConf
 from fairseq.dataclass.utils import convert_namespace_to_omegaconf
 
 
@@ -381,7 +381,7 @@ class W2lFairseqLMDecoder(W2lDecoder):
         checkpoint = torch.load(args.kenlm_model, map_location="cpu")
 
         if "cfg" in checkpoint and checkpoint["cfg"] is not None:
-            lm_args = checkpoint["cfg"]
+            lm_args = OmegaConf.create(checkpoint["cfg"])
         else:
             lm_args = convert_namespace_to_omegaconf(checkpoint["args"])
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements) 
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

Summery:
- Using OmegaConf to convert checkpoint["cfg"] dict in speech-recognition's infer
- Updated to f34abcf2

## What does this PR do?
Fixes #2838,  resolves #3488 

The `cfg` in the [checkpoint = torch.load(args.kenlm_model, map_location="cpu")](https://github.com/pytorch/fairseq/blob/9549e7f76994095c92441b81c615a169dc21f478/examples/speech_recognition/w2l_decoder.py#L381) is a dict. However, it is treated as a OmegaConf. Just followed lines 322-334 of fairseq.checkpoint_utils to fix it