### PR TITLE
make min_phones use in prepare_text.sh consistent

### DIFF
--- a/examples/wav2vec/unsupervised/scripts/prepare_text.sh
+++ b/examples/wav2vec/unsupervised/scripts/prepare_text.sh
@@ -44,7 +44,7 @@ echo "min phone seen threshold is $min_phones"
 
 mkdir -p $target_dir
 python $FAIRSEQ_ROOT/examples/wav2vec/unsupervised/scripts/normalize_and_filter_text.py --lang $lg --fasttext-model $lid_path < $text_path | grep -v '\-\-\-' >! $target_dir/lm.upper.lid.txt
-python $FAIRSEQ_ROOT/fairseq_cli/preprocess.py --dataset-impl mmap --trainpref $target_dir/lm.upper.lid.txt --only-source --destdir $target_dir --thresholdsrc 2 --padding-factor 1 --dict-only
+python $FAIRSEQ_ROOT/fairseq_cli/preprocess.py --dataset-impl mmap --trainpref $target_dir/lm.upper.lid.txt --only-source --destdir $target_dir --thresholdsrc $min_phones --padding-factor 1 --dict-only
 cut -f1 -d' ' $target_dir/dict.txt | grep -v -x '[[:punct:]]*' | grep -Pv '\d\d\d\d\d+' >! $target_dir/words.txt
 
 


### PR DESCRIPTION
One instance of thresholdsrc uses $min_phones, the other does not. 
Therefore any word that shows up less than 2 times does not end up in dict.txt, causing any sentence containing said words to be rejected. 
This causes trouble especially for small datasets.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes #3901

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
