### PR TITLE
Update the encode function in BART hub_interface: to add an extra option for not always adding OOV tokens into vocabulary 

### DIFF
--- a/fairseq/models/bart/hub_interface.py
+++ b/fairseq/models/bart/hub_interface.py
@@ -31,7 +31,11 @@ class BARTHubInterface(GeneratorHubInterface):
         self.model = self.models[0]
 
     def encode(
-        self, sentence: str, *addl_sentences, no_separator=True
+        self, 
+        sentence: str, 
+        *addl_sentences, 
+        no_separator=True,
+        add_if_not_exist=True
     ) -> torch.LongTensor:
         """
         BPE-encode a sentence (or multiple sentences).
@@ -59,7 +63,9 @@ class BARTHubInterface(GeneratorHubInterface):
         for s in addl_sentences:
             bpe_sentence += " </s>" if not no_separator else ""
             bpe_sentence += " " + self.bpe.encode(s) + " </s>"
-        tokens = self.task.source_dictionary.encode_line(bpe_sentence, append_eos=False)
+        tokens = self.task.source_dictionary.encode_line(
+            bpe_sentence, append_eos=False, add_if_not_exist=add_if_not_exist
+        )
         return tokens.long()
 
     def decode(self, tokens: torch.LongTensor):


### PR DESCRIPTION
Regarding this [code line 62](https://github.com/pytorch/fairseq/blob/fcca32258c8e8bcc9f9890bf4714fa2f96b6b3e1/fairseq/models/bart/hub_interface.py#L62) in the `encode` function in BART hub_interface, in many cases (e.g. using a monolingual vocabulary reduced from an existing multilingual one), an OOV token should be aligned with `<unk>` index, rather than always being added as a new token type into the vocabulary. 

Recent code: https://github.com/pytorch/fairseq/blob/main/fairseq/models/bart/hub_interface.py

```python
    def encode(
        self, sentence: str, *addl_sentences, no_separator=True
    ) -> torch.LongTensor:
        tokens = self.bpe.encode(sentence)
        if len(tokens.split(" ")) > min(self.max_positions) - 2:
            tokens = " ".join(tokens.split(" ")[: min(self.max_positions) - 2])
        bpe_sentence = "<s> " + tokens + " </s>"
        for s in addl_sentences:
            bpe_sentence += " </s>" if not no_separator else ""
            bpe_sentence += " " + self.bpe.encode(s) + " </s>"
        tokens = self.task.source_dictionary.encode_line(bpe_sentence, append_eos=False) # Always add OOV token as new type
        return tokens.long()
```

Suggest to be as follows (https://github.com/datquocnguyen/fairseq/blob/main/fairseq/models/bart/hub_interface.py):

```python
    def encode(
        self, 
        sentence: str, 
        *addl_sentences, 
        no_separator=True,
        add_if_not_exist=True # Add an extra option
    ) -> torch.LongTensor:
        tokens = self.bpe.encode(sentence)
        if len(tokens.split(" ")) > min(self.max_positions) - 2:
            tokens = " ".join(tokens.split(" ")[: min(self.max_positions) - 2])
        bpe_sentence = "<s> " + tokens + " </s>"
        for s in addl_sentences:
            bpe_sentence += " </s>" if not no_separator else ""
            bpe_sentence += " " + self.bpe.encode(s) + " </s>"
        tokens = self.task.source_dictionary.encode_line(
            bpe_sentence, append_eos=False, add_if_not_exist=add_if_not_exist
        )
        return tokens.long()
```

With this suggested code, in the case mentioned above, encoding should be `fairseq_model.encode(sentence, add_if_not_exist=False)`

For mBART and the like, it still encodes and adds extra token types into the vocabulary (e.g. training for new languages) as before: `fairseq_model.encode(sentence)`


