### PR TITLE
Support decimal label rate

### DIFF
--- a/fairseq/data/audio/hubert_dataset.py
+++ b/fairseq/data/audio/hubert_dataset.py
@@ -141,7 +141,7 @@ class HubertDataset(FairseqDataset):
         self.single_target = single_target
         self.label_rates = (
             [label_rates for _ in range(len(label_paths))]
-            if isinstance(label_rates, int)
+            if isinstance(label_rates, float)
             else label_rates
         )
         self.store_labels = store_labels
@@ -302,7 +302,7 @@ class HubertDataset(FairseqDataset):
         targets_list, lengths_list, ntokens_list = [], [], []
         itr = zip(targets_by_label, self.label_rates, self.pad_list)
         for targets, label_rate, pad in itr:
-            if label_rate == -1:
+            if label_rate == -1.0:
                 targets, lengths, ntokens = self.collater_seq_label(targets, pad)
             else:
                 targets, lengths, ntokens = self.collater_frm_label(

--- a/fairseq/models/hubert/hubert.py
+++ b/fairseq/models/hubert/hubert.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class HubertConfig(FairseqDataclass):
-    label_rate: int = II("task.label_rate")
+    label_rate: float = II("task.label_rate")
 
     extractor_mode: EXTRACTOR_MODE_CHOICES = field(
         default="default",

--- a/fairseq/tasks/hubert_pretraining.py
+++ b/fairseq/tasks/hubert_pretraining.py
@@ -55,9 +55,9 @@ class HubertPretrainingConfig(FairseqDataclass):
             "help": "if set, looks for labels in this directory instead",
         },
     )
-    label_rate: int = field(
-        default=-1,
-        metadata={"help": "label frame rate. -1 for sequence label"},
+    label_rate: float = field(
+        default=-1.0,
+        metadata={"help": "label frame rate. -1.0 for sequence label"},
     )
     sample_rate: int = field(
         default=16_000,


### PR DESCRIPTION
Make label_rate be of type float in Hubert pretraining to support decimal label rate (e.g. 33.3Hz, otherwise verify_label_lengths() will give warnings if the undelying label rate is 33.3Hz)

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
