### PR TITLE
Fixes OOM bug causing distributed training jobs to hang.

### DIFF
--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -783,6 +783,10 @@ class Trainer(object):
                         torch.cuda.empty_cache()
                     if self.cfg.distributed_training.distributed_world_size == 1:
                         return None
+                    else:
+                        # Re-raise exception, as otherwise distributed workers
+                        # get out of sync and cause the training job to hang.
+                        raise
                 else:
                     raise e
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [X] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [X] Did you make sure to update the docs?
- [X] Did you write any new necessary tests?

## What does this PR do?
Fixes issue where fairseq training hangs when using multiple workers. When one of the workers gets a OOM error, it tries to recover with a `try ... except` statement, but the other workers keep waiting for it, and they get out of sync.
