### PR TITLE
enables audio padding rather than cropping for HuBERT finetuning and decoding. Also fixes the issue that the decoding results are non-deterministic due to random audio cropping

### DIFF
--- a/examples/hubert/config/decode/infer_fsqlm.yaml
+++ b/examples/hubert/config/decode/infer_fsqlm.yaml
@@ -16,6 +16,7 @@ task:
   fine_tuning: true
   data: ???
   normalize: ???
+  pad_audio: true
 
 decoding:
   type: fairseqlm

--- a/examples/hubert/config/decode/infer_kenlm.yaml
+++ b/examples/hubert/config/decode/infer_kenlm.yaml
@@ -16,6 +16,7 @@ task:
   fine_tuning: true
   data: ???
   normalize: ???
+  pad_audio: true
 
 decoding:
   type: kenlm

--- a/examples/hubert/config/decode/infer_viterbi.yaml
+++ b/examples/hubert/config/decode/infer_viterbi.yaml
@@ -16,6 +16,7 @@ task:
   fine_tuning: true
   data: ???
   normalize: ???
+  pad_audio: true
 
 decoding:
   type: viterbi

--- a/examples/hubert/config/finetune/base_10h.yaml
+++ b/examples/hubert/config/finetune/base_10h.yaml
@@ -28,6 +28,7 @@ task:
   normalize: false  # must be consistent with pre-training
   labels: ["ltr"]
   single_target: true
+  pad_audio: true
 
 dataset:
   num_workers: 0

--- a/fairseq/tasks/hubert_pretraining.py
+++ b/fairseq/tasks/hubert_pretraining.py
@@ -180,7 +180,7 @@ class HubertPretrainingTask(FairseqTask):
             pad_audio=self.cfg.pad_audio,
             normalize=self.cfg.normalize,
             store_labels=False,
-            random_crop=self.cfg.random_crop,
+            random_crop=(not self.cfg.fine_tuning and self.cfg.random_crop),
             single_target=self.cfg.single_target,
         )
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Enables audio padding rather than cropping for HuBERT finetuning and decoding (it shouldn't crop the audio during CTC finetuning, otherwise we may lose audio corresponding to some part of the transcript). Also fixes the issue that the decoding results of HuBERT  models are non-deterministic across different runs of inference with exactly the same setting, by disabling random_crop during inference (also disable it for the fine-tuning stage, as there seems no point doing wave crop for fine-tuning, which is also consistent with wav2vec2).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
