### PR TITLE
TransformerDecoderBase: disable future mask caching during ONNX trace

### DIFF
--- a/fairseq/models/transformer/transformer_decoder.py
+++ b/fairseq/models/transformer/transformer_decoder.py
@@ -390,6 +390,9 @@ class TransformerDecoderBase(FairseqIncrementalDecoder):
             self._future_mask.size(0) == 0
             or (not self._future_mask.device == tensor.device)
             or self._future_mask.size(0) < dim
+            # Ensure tracing always includes the initialization,
+            # since it doesn't correctly handle the conditional.
+            or self.onnx_trace
         ):
             self._future_mask = torch.triu(
                 utils.fill_with_neg_inf(torch.zeros([dim, dim])), 1


### PR DESCRIPTION
If the model is traced when self._future_mask was already initialized,
it would not be initialized during the trace, which results in an
incorrect ONNX model.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Fixes #4026