### PR TITLE
fix: crash when use cpu_adam

### DIFF
--- a/fairseq/optim/cpu_adam.py
+++ b/fairseq/optim/cpu_adam.py
@@ -116,8 +116,10 @@ class CPUAdam(torch.optim.Optimizer):
 
         self.ds_opt_adam = _get_cpu_adam()
         adamw_mode = True
+        # new deepspeed's create_adam_optimizer add argument 'should_log'
+        should_log = False
         self.ds_opt_adam.create_adam(
-            self.opt_id, lr, betas[0], betas[1], eps, weight_decay, adamw_mode
+            self.opt_id, lr, betas[0], betas[1], eps, weight_decay, adamw_mode, should_log
         )
 
     @property


### PR DESCRIPTION
Follow FSDP tutorial, fairseq crashed when set --optimizer=cpu_adam, because new deepspeed's create_adam_optimizer add an argument 'should_log'.

issue: https://github.com/pytorch/fairseq/issues/3810#issue-975829307

original error message:
TypeError:
create_adam(): incompatible function arguments. The following argument types are supported:
    1. (arg0: int, arg1: float, arg2: float, arg3: float, arg4: float, arg5: float, arg6: bool, arg7: bool) -> int