### PR TITLE
Fixed a bug of ReduceLROnPlateauLRSchedule

### DIFF
--- a/fairseq/optim/lr_scheduler/reduce_lr_on_plateau.py
+++ b/fairseq/optim/lr_scheduler/reduce_lr_on_plateau.py
@@ -109,6 +109,7 @@ class ReduceLROnPlateauLRSchedule(FairseqLRScheduler):
         return {
             "best": self.lr_scheduler.best,
             "last_epoch": self.lr_scheduler.last_epoch,
+            "num_bad_epochs": self.lr_scheduler.num_bad_epochs,
         }
 
     def load_state_dict(self, state_dict):
@@ -116,6 +117,8 @@ class ReduceLROnPlateauLRSchedule(FairseqLRScheduler):
         self.lr_scheduler.best = state_dict["best"]
         if "last_epoch" in state_dict:
             self.lr_scheduler.last_epoch = state_dict["last_epoch"]
+        if "num_bad_epochs" in state_dict:
+            self.lr_scheduler.num_bad_epochs = state_dict["num_bad_epochs"]
 
     def step(self, epoch, val_loss=None):
         """


### PR DESCRIPTION
The num_bad_epochs state is required to resume consistent training in
ReduceLROnPlateau LR Scheduler.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Adds the `num_bad_epochs` to the `ReduceLROnPlateauLRSchedule` 's state_dict to resume consistent training.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
