### PR TITLE
Compute bleu fixes

### DIFF
--- a/fairseq/tasks/translation.py
+++ b/fairseq/tasks/translation.py
@@ -438,8 +438,8 @@ class TranslationTask(FairseqTask):
                     bleu = comp_bleu(
                         correct=meters["_bleu_counts"].sum,
                         total=meters["_bleu_totals"].sum,
-                        sys_len=meters["_bleu_sys_len"].sum,
-                        ref_len=meters["_bleu_ref_len"].sum,
+                        sys_len=int(meters["_bleu_sys_len"].sum),
+                        ref_len=int(meters["_bleu_ref_len"].sum),
                         **smooth,
                     )
                     return round(bleu.score, 2)


### PR DESCRIPTION
# Before submitting

- [No ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [Yes] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [Yes] Did you make sure to update the docs?
- [No ] Did you write any new necessary tests?

## What does this PR do?
Fixes # (issue).When training with multiple GPU, the value of meters["_bleu_sys_len"].sum  and meters["_bleu_ref_len"].sum is float, while compute_blue function requires an integer input

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
