### PR TITLE
Data load offsets and lengths

### DIFF
--- a/fairseq/data/audio/audio_utils.py
+++ b/fairseq/data/audio/audio_utils.py
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import dataclasses
+import os
 from pathlib import Path
 from typing import BinaryIO, Optional, Tuple, Union, List
 import mmap
@@ -15,6 +17,20 @@ import torch.nn.functional as F
 
 SF_AUDIO_FILE_EXTENSIONS = {".wav", ".flac", ".ogg"}
 FEATURE_OR_SF_AUDIO_FILE_EXTENSIONS = {".npy", ".wav", ".flac", ".ogg"}
+ZIP_FILE_EXTENSIONS = {".zip"}
+
+
+@dataclasses.dataclass
+class ParsedPath:
+    path: str
+    zip_offset: int = 0
+    zip_length: int = -1
+    start: int = 0
+    frames: int = -1
+    is_zip: bool = False
+
+    def __post_init__(self):
+        self.is_zip = Path(self.path).suffix in ZIP_FILE_EXTENSIONS
 
 
 def convert_waveform(
@@ -158,12 +174,12 @@ def _get_torchaudio_fbank(
         return None
 
 
-def get_fbank(path_or_fp: Union[str, BinaryIO], n_bins=80) -> np.ndarray:
+def get_fbank(path_or_fp: Union[str, BinaryIO], n_bins=80, start=0, frames=-1) -> np.ndarray:
     """Get mel-filter bank features via PyKaldi or TorchAudio. Prefer PyKaldi
     (faster CPP implementation) to TorchAudio (Python implementation). Note that
     Kaldi/TorchAudio requires 16-bit signed integers as inputs and hence the
     waveform should not be normalized."""
-    waveform, sample_rate = get_waveform(path_or_fp, normalization=False)
+    waveform, sample_rate = get_waveform(path_or_fp, normalization=False, start=start, frames=frames)
 
     features = _get_kaldi_fbank(waveform, sample_rate, n_bins)
     if features is None:
@@ -191,7 +207,10 @@ def is_sf_audio_data(data: bytes) -> bool:
 def mmap_read(path: str, offset: int, length: int) -> bytes:
     with open(path, "rb") as f:
         with mmap.mmap(f.fileno(), length=0, access=mmap.ACCESS_READ) as mmap_o:
-            data = mmap_o[offset : offset + length]
+            if length > 0:
+                data = mmap_o[offset : offset + length]
+            else:
+                data = mmap_o[offset:]
     return data
 
 
@@ -199,7 +218,7 @@ def read_from_stored_zip(zip_path: str, offset: int, length: int) -> bytes:
     return mmap_read(zip_path, offset, length)
 
 
-def parse_path(path: str) -> Tuple[str, List[int]]:
+def parse_path(path: str) -> ParsedPath:
     """Parse data path which is either a path to
     1. a .npy/.wav/.flac/.ogg file
     2. a stored ZIP file with slicing info: "[zip_path]:[offset]:[length]"
@@ -213,15 +232,22 @@ def parse_path(path: str) -> Tuple[str, List[int]]:
             byte offset and length for the slice in case 2
     """
 
-    if Path(path).suffix in FEATURE_OR_SF_AUDIO_FILE_EXTENSIONS:
-        _path, slice_ptr = path, []
-    else:
-        _path, *slice_ptr = path.split(":")
-        if not Path(_path).is_file():
+    _path, *slice_ptr = path.split(":")
+    parsed_path = ParsedPath(_path)
+
+    if parsed_path.is_zip:
+        if not os.path.isfile(_path):
             raise FileNotFoundError(f"File not found: {_path}")
-    assert len(slice_ptr) in {0, 2}, f"Invalid path: {path}"
-    slice_ptr = [int(i) for i in slice_ptr]
-    return _path, slice_ptr
+        if len(slice_ptr) == 2:
+            parsed_path = dataclasses.replace(parsed_path, zip_offset=int(slice_ptr[0]), zip_length=int(slice_ptr[1]))
+        elif len(slice_ptr) > 0:
+            raise ValueError(f"Invalid path: {path}")
+    else:
+        if len(slice_ptr) == 2:
+            parsed_path = dataclasses.replace(parsed_path, start=int(slice_ptr[0]), frames=int(slice_ptr[1]))
+        elif len(slice_ptr) > 0:
+            raise ValueError(f"Invalid path: {path}")
+    return parsed_path
 
 
 def get_window(window_fn: callable, n_fft: int, win_length: int) -> torch.Tensor:

--- a/fairseq/data/audio/audio_utils.py
+++ b/fairseq/data/audio/audio_utils.py
@@ -5,15 +5,14 @@
 
 
 import dataclasses
+import mmap
 import os
 from pathlib import Path
-from typing import BinaryIO, Optional, Tuple, Union, List
-import mmap
+from typing import BinaryIO, Optional, Tuple, Union
 
 import numpy as np
 import torch
 import torch.nn.functional as F
-
 
 SF_AUDIO_FILE_EXTENSIONS = {".wav", ".flac", ".ogg"}
 FEATURE_OR_SF_AUDIO_FILE_EXTENSIONS = {".npy", ".wav", ".flac", ".ogg"}
@@ -139,7 +138,7 @@ def _get_kaldi_fbank(
 ) -> Optional[np.ndarray]:
     """Get mel-filter bank features via PyKaldi."""
     try:
-        from kaldi.feat.fbank import FbankOptions, Fbank
+        from kaldi.feat.fbank import Fbank, FbankOptions
         from kaldi.feat.mel import MelBanksOptions
         from kaldi.feat.window import FrameExtractionOptions
         from kaldi.matrix import Vector
@@ -174,12 +173,16 @@ def _get_torchaudio_fbank(
         return None
 
 
-def get_fbank(path_or_fp: Union[str, BinaryIO], n_bins=80, start=0, frames=-1) -> np.ndarray:
+def get_fbank(
+    path_or_fp: Union[str, BinaryIO], n_bins=80, start=0, frames=-1
+) -> np.ndarray:
     """Get mel-filter bank features via PyKaldi or TorchAudio. Prefer PyKaldi
     (faster CPP implementation) to TorchAudio (Python implementation). Note that
     Kaldi/TorchAudio requires 16-bit signed integers as inputs and hence the
     waveform should not be normalized."""
-    waveform, sample_rate = get_waveform(path_or_fp, normalization=False, start=start, frames=frames)
+    waveform, sample_rate = get_waveform(
+        path_or_fp, normalization=False, start=start, frames=frames
+    )
 
     features = _get_kaldi_fbank(waveform, sample_rate, n_bins)
     if features is None:
@@ -239,12 +242,16 @@ def parse_path(path: str) -> ParsedPath:
         if not os.path.isfile(_path):
             raise FileNotFoundError(f"File not found: {_path}")
         if len(slice_ptr) == 2:
-            parsed_path = dataclasses.replace(parsed_path, zip_offset=int(slice_ptr[0]), zip_length=int(slice_ptr[1]))
+            parsed_path = dataclasses.replace(
+                parsed_path, zip_offset=int(slice_ptr[0]), zip_length=int(slice_ptr[1])
+            )
         elif len(slice_ptr) > 0:
             raise ValueError(f"Invalid path: {path}")
     else:
         if len(slice_ptr) == 2:
-            parsed_path = dataclasses.replace(parsed_path, start=int(slice_ptr[0]), frames=int(slice_ptr[1]))
+            parsed_path = dataclasses.replace(
+                parsed_path, start=int(slice_ptr[0]), frames=int(slice_ptr[1])
+            )
         elif len(slice_ptr) > 0:
             raise ValueError(f"Invalid path: {path}")
     return parsed_path

--- a/fairseq/data/audio/raw_audio_dataset.py
+++ b/fairseq/data/audio/raw_audio_dataset.py
@@ -312,14 +312,20 @@ class FileAudioDataset(RawAudioDataset):
         fn = self.fnames[index]
         fn = fn if isinstance(self.fnames, list) else fn.as_py()
         fn = self.text_compressor.decompress(fn)
-        path_or_fp = os.path.join(self.root_dir, fn)
-        _path, slice_ptr = parse_path(path_or_fp)
-        if len(slice_ptr) == 2:
-            byte_data = read_from_stored_zip(_path, slice_ptr[0], slice_ptr[1])
-            assert is_sf_audio_data(byte_data)
+        parsed = parse_path(os.path.join(self.root_dir, fn))
+        path_or_fp = parsed.path
+
+        if parsed.is_zip:
+            byte_data = read_from_stored_zip(parsed.path, parsed.zip_offset, parsed.zip_length)
+            assert is_sf_audio_data(byte_data), f"{fn} did not contain valid audio data"
             path_or_fp = io.BytesIO(byte_data)
 
-        wav, curr_sample_rate = sf.read(path_or_fp, dtype="float32")
+        wav, curr_sample_rate = sf.read(path_or_fp, frames=parsed.frames, start=parsed.start, dtype="float32", always_2d=True)
+
+        if parsed.frames:
+            assert parsed.frames == -1 or parsed.frames == wav.shape[0], \
+                f"Reading {path_or_fp} from frame {parsed.start}. " \
+                f"Requested {parsed.frames} frames, got {wav.shape[0]} instead."
 
         feats = torch.from_numpy(wav).float()
         feats = self.postprocess(feats, curr_sample_rate)

--- a/fairseq/data/audio/raw_audio_dataset.py
+++ b/fairseq/data/audio/raw_audio_dataset.py
@@ -4,24 +4,24 @@
 # LICENSE file in the root directory of this source tree.
 
 
+import io
 import logging
 import os
 import sys
-import io
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 
-from .. import FairseqDataset
-from ..data_utils import compute_mask_indices, get_buckets, get_bucketed_sizes
 from fairseq.data.audio.audio_utils import (
+    is_sf_audio_data,
     parse_path,
     read_from_stored_zip,
-    is_sf_audio_data,
 )
-from fairseq.data.text_compressor import TextCompressor, TextCompressionLevel
+from fairseq.data.text_compressor import TextCompressionLevel, TextCompressor
 
+from .. import FairseqDataset
+from ..data_utils import compute_mask_indices, get_bucketed_sizes, get_buckets
 
 logger = logging.getLogger(__name__)
 
@@ -316,16 +316,25 @@ class FileAudioDataset(RawAudioDataset):
         path_or_fp = parsed.path
 
         if parsed.is_zip:
-            byte_data = read_from_stored_zip(parsed.path, parsed.zip_offset, parsed.zip_length)
+            byte_data = read_from_stored_zip(
+                parsed.path, parsed.zip_offset, parsed.zip_length
+            )
             assert is_sf_audio_data(byte_data), f"{fn} did not contain valid audio data"
             path_or_fp = io.BytesIO(byte_data)
 
-        wav, curr_sample_rate = sf.read(path_or_fp, frames=parsed.frames, start=parsed.start, dtype="float32", always_2d=True)
+        wav, curr_sample_rate = sf.read(
+            path_or_fp,
+            frames=parsed.frames,
+            start=parsed.start,
+            dtype="float32",
+            always_2d=True,
+        )
 
         if parsed.frames:
-            assert parsed.frames == -1 or parsed.frames == wav.shape[0], \
-                f"Reading {path_or_fp} from frame {parsed.start}. " \
+            assert parsed.frames == -1 or parsed.frames == wav.shape[0], (
+                f"Reading {path_or_fp} from frame {parsed.start}. "
                 f"Requested {parsed.frames} frames, got {wav.shape[0]} instead."
+            )
 
         feats = torch.from_numpy(wav).float()
         feats = self.postprocess(feats, curr_sample_rate)
@@ -358,7 +367,7 @@ class BinarizedAudioDataset(RawAudioDataset):
             **mask_compute_kwargs,
         )
 
-        from fairseq.data import data_utils, Dictionary
+        from fairseq.data import Dictionary, data_utils
 
         self.fnames_dict = Dictionary.load(os.path.join(data_dir, "dict.txt"))
 

--- a/fairseq/data/audio/speech_to_text_dataset.py
+++ b/fairseq/data/audio/speech_to_text_dataset.py
@@ -8,31 +8,26 @@ import io
 import logging
 import re
 from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
-from dataclasses import dataclass
 
 import numpy as np
 import torch
-from fairseq.data import (
-    ConcatDataset,
-    Dictionary,
-    FairseqDataset,
-    ResamplingDataset,
-    data_utils as fairseq_data_utils,
-)
+
+from fairseq.data import ConcatDataset, Dictionary, FairseqDataset, ResamplingDataset
+from fairseq.data import data_utils as fairseq_data_utils
 from fairseq.data.audio.audio_utils import (
+    FEATURE_OR_SF_AUDIO_FILE_EXTENSIONS,
     get_fbank,
     get_waveform,
-    read_from_stored_zip,
     is_npy_data,
     is_sf_audio_data,
     parse_path,
-    FEATURE_OR_SF_AUDIO_FILE_EXTENSIONS,
+    read_from_stored_zip,
 )
-from fairseq.data.audio.feature_transforms import CompositeAudioFeatureTransform
 from fairseq.data.audio.data_cfg import S2TDataConfig
-
+from fairseq.data.audio.feature_transforms import CompositeAudioFeatureTransform
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +36,9 @@ def get_features_from_npy_or_audio(path: str, start: int = 0, frames: int = -1):
     ext = Path(path).suffix
     if ext not in FEATURE_OR_SF_AUDIO_FILE_EXTENSIONS:
         raise ValueError(f'Unsupported file format for "{path}"')
-    return np.load(path) if ext == ".npy" else get_fbank(path, start=start, frames=frames)
+    return (
+        np.load(path) if ext == ".npy" else get_fbank(path, start=start, frames=frames)
+    )
 
 
 def get_features_or_waveform_from_stored_zip(
@@ -91,14 +88,16 @@ def get_features_or_waveform(path: str, need_waveform=False, use_sample_rate=Non
                 frames=parsed.frames,
                 start=parsed.start,
             )[0]
-        return get_features_from_npy_or_audio(parsed.path, start=parsed.start, frames=parsed.frames)
+        return get_features_from_npy_or_audio(
+            parsed.path, start=parsed.start, frames=parsed.frames
+        )
     else:
         return get_features_or_waveform_from_stored_zip(
             parsed.path,
             byte_offset=parsed.zip_offset,
             byte_size=parsed.zip_length,
             need_waveform=need_waveform,
-            use_sample_rate=use_sample_rate
+            use_sample_rate=use_sample_rate,
         )
 
 

--- a/tests/test_dataset_offsets_and_lengths.py
+++ b/tests/test_dataset_offsets_and_lengths.py
@@ -1,0 +1,204 @@
+import contextlib
+import mmap
+import os
+import unittest
+from io import BytesIO
+from typing import Dict, Union
+from unittest.mock import patch, MagicMock, mock_open
+
+import numpy
+import numpy as np
+import soundfile
+
+from fairseq.data import FileAudioDataset
+from fairseq.data.audio.audio_utils import parse_path, ParsedPath
+from fairseq.data.audio.speech_to_text_dataset import get_features_or_waveform
+
+SAMPLE_RATE = 16000
+
+_soundfile_read = soundfile.read
+
+TEST_SEQUENCE = np.linspace(-1, 1, 9999)
+
+
+class TestParsePathOffsetsAndLengths(unittest.TestCase):
+    def test_parse_path(self):
+        test_cases = [
+            (
+                "wav file with no offset/length",
+                "/path/to/myfile.wav",
+                ParsedPath("/path/to/myfile.wav", start=0, frames=-1, zip_offset=0, zip_length=-1)
+            ),
+            (
+                "wav file with offset & length",
+                "/path/to/myfile.wav:123:456",
+                ParsedPath("/path/to/myfile.wav", start=123, frames=456, zip_offset=0, zip_length=-1)
+            ),
+            (
+                "zip file with no offset/length",
+                "/path/to/myfile.zip",
+                ParsedPath("/path/to/myfile.zip", start=0, frames=-1, zip_offset=0, zip_length=-1)
+            ),
+            (
+                "zip file with offset & length",
+                "/path/to/myfile.zip:123:456",
+                ParsedPath("/path/to/myfile.zip", start=0, frames=-1, zip_offset=123, zip_length=456)
+            ),
+        ]
+
+        for subtest, path, expected in test_cases:
+            with self.subTest(subtest):
+                with patch("os.path.isfile", return_value=True):
+                    actual = parse_path(path)
+                self.assertEqual(actual, expected)
+
+
+class TestDatasetOffsetsAndLengths(unittest.TestCase):
+    def test_file_audio_dataset_audio_with_offsets_etc(self):
+        files = {
+            "/path/to/myfile1.wav": encode_as_wav(TEST_SEQUENCE),
+            "/path/to/myfile2.wav": encode_as_wav(TEST_SEQUENCE),
+            "/path/to/myfile1.zip": encode_as_wav(TEST_SEQUENCE, pad_zip=123),
+            "/path/to/myfile2.zip": encode_as_wav(TEST_SEQUENCE),
+        }
+        manifest_text = [
+            "/dev/null",
+            "/path/to/myfile1.wav:123:456\t456",
+            "/path/to/myfile2.wav\t456",
+            "/path/to/myfile1.zip:123:456\t456",
+            "/path/to/myfile2.zip\t456"
+        ]
+        expected_data = [
+            TEST_SEQUENCE[123:123+456],
+            TEST_SEQUENCE,
+            TEST_SEQUENCE[:206],
+            TEST_SEQUENCE
+        ]
+
+        files["/dev/null/train.tsv"] = os.linesep.join(manifest_text)
+
+        with mock_files(files):
+            dataset = FileAudioDataset("/dev/null/train.tsv", sample_rate=SAMPLE_RATE)
+            assert len(expected_data) == len(dataset)
+            for item, expected_sequence in zip(dataset, expected_data):
+                filename = dataset.fnames[item["id"]]
+                with self.subTest(filename):
+                    numpy.testing.assert_almost_equal(item["source"].numpy(), expected_sequence, decimal=4)
+
+    def test_file_audio_dataset_zip_with_offsets_etc(self):
+        files = {
+            "/path/to/myfile1.wav": encode_as_wav(TEST_SEQUENCE),
+            "/path/to/myfile2.wav": encode_as_wav(TEST_SEQUENCE),
+            "/path/to/myfile3.wav": encode_as_wav(TEST_SEQUENCE),
+            "/path/to/myfile4.zip": encode_as_wav(TEST_SEQUENCE),
+            "/path/to/myfile5.zip": encode_as_wav(TEST_SEQUENCE, pad_zip=123),
+        }
+        manifest_text = [
+            "/dev/null",
+            "/path/to/myfile1.wav\t9999",
+            "/path/to/myfile2.wav:123:456\t456",
+            "/path/to/myfile3.wav:456:789\t789",
+            "/path/to/myfile4.zip\t9999",
+            "/path/to/myfile5.zip:123:456\t456",
+        ]
+        expected = [
+            ("wav file, no offset, should return what we give it.", TEST_SEQUENCE),
+            ("wav file with offset 123, length 456", TEST_SEQUENCE[123:123 + 456]),
+            ("wav file with offset 456, length 789", TEST_SEQUENCE[456:456 + 789]),
+            ("zip file with no offset/length", TEST_SEQUENCE),
+            ("zip file provides *byte* offset & length. Will cut off wav files longer than that.", TEST_SEQUENCE[:206]),
+        ]
+
+        files["/dev/null/train.tsv"] = os.linesep.join(manifest_text)
+
+        with mock_files(files):
+            dataset = FileAudioDataset("/dev/null/train.tsv", sample_rate=SAMPLE_RATE)
+            self.assertEqual(len(dataset.fnames), len(expected))
+
+            for item, (message, expected_sequence) in zip(dataset, expected):
+                with self.subTest(message):
+                    numpy.testing.assert_almost_equal(item["source"].numpy().flatten(), expected_sequence, decimal=4)
+
+    def test_get_features_or_waveform(self):
+        files = {
+            "/path/to/myfile1.wav": encode_as_wav(TEST_SEQUENCE),
+            "/path/to/myfile2.wav": encode_as_wav(TEST_SEQUENCE),
+            "/path/to/myfile3.wav": encode_as_wav(TEST_SEQUENCE),
+            "/path/to/myfile4.zip": encode_as_wav(TEST_SEQUENCE),
+            "/path/to/myfile5.zip": encode_as_wav(TEST_SEQUENCE, pad_zip=456),
+        }
+        test_cases = [
+            (
+                "wav file, no offset, should return what we give it.",
+                "/path/to/myfile1.wav",
+                TEST_SEQUENCE,
+            ),
+            (
+                "wav file with offset 123, length 456",
+                "/path/to/myfile2.wav:123:456",
+                TEST_SEQUENCE[123:123+456],
+            ),
+            (
+                "wav file with offset 456, length 789",
+                "/path/to/myfile3.wav:456:789",
+                TEST_SEQUENCE[456:456+789],
+            ),
+            (
+                "zip file with no offset/length",
+                "/path/to/myfile4.zip",
+                TEST_SEQUENCE,
+            ),
+            (
+                "zip file provides *byte* offset & length. Will cut off wav files longer than that.",
+                "/path/to/myfile5.zip:456:123",
+                TEST_SEQUENCE[:39],
+            ),
+        ]
+
+        with mock_files(files):
+            for message, filename_unparsed, expected_sequence in test_cases:
+                with self.subTest(message):
+                    features = get_features_or_waveform(filename_unparsed, need_waveform=True)
+                    numpy.testing.assert_almost_equal(expected_sequence, features.flatten(), decimal=4)
+
+
+def encode_as_wav(x, sample_rate=SAMPLE_RATE, pad_zip=0):
+    bytes_io = BytesIO()
+    soundfile.write(bytes_io, x, samplerate=sample_rate, format="wav")
+    pad = bytes(ord("0") + (n % 10) for n in range(pad_zip))
+    return pad + bytes_io.getvalue()
+
+
+@contextlib.contextmanager
+def mock_files(file_dict: Dict[str, Union[bytes, str]]):
+
+    def builtins_open(file, mode='r', *args, **kwargs):
+        data = file_dict[file]
+        if 'b' not in mode and isinstance(data, bytes):
+            data = data.decode()
+        mo = mock_open(read_data=data)
+        mo.return_value.fileno.return_value = file
+        return mo(file, mode, *args, **kwargs)
+
+    def soundfile_read(file, *args, **kwargs):
+        if isinstance(file, str) and file in file_dict:
+            file = BytesIO(file_dict[file])
+        return _soundfile_read(file, *args, **kwargs)
+
+    def mmap_mmap(file, *args, **kwargs):
+        return MagicMock(**{"__enter__.return_value": file_dict[file]})
+
+    with patch("soundfile.read", side_effect=soundfile_read) as mock_soundfile_read, \
+         patch("os.path.isfile", return_value=True) as mock_isfile, \
+         patch("builtins.open", side_effect=builtins_open) as mock_builtins_open, \
+         patch("mmap.mmap", side_effect=mmap_mmap) as mock_mmap:
+
+        assert open is mock_builtins_open
+        assert os.path.isfile is mock_isfile
+        assert soundfile.read is mock_soundfile_read
+        assert mmap.mmap is mock_mmap
+        yield
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_dataset_offsets_and_lengths.py
+++ b/tests/test_dataset_offsets_and_lengths.py
@@ -4,14 +4,14 @@ import os
 import unittest
 from io import BytesIO
 from typing import Dict, Union
-from unittest.mock import patch, MagicMock, mock_open
+from unittest.mock import MagicMock, mock_open, patch
 
 import numpy
 import numpy as np
 import soundfile
 
 from fairseq.data import FileAudioDataset
-from fairseq.data.audio.audio_utils import parse_path, ParsedPath
+from fairseq.data.audio.audio_utils import ParsedPath, parse_path
 from fairseq.data.audio.speech_to_text_dataset import get_features_or_waveform
 
 SAMPLE_RATE = 16000
@@ -27,22 +27,46 @@ class TestParsePathOffsetsAndLengths(unittest.TestCase):
             (
                 "wav file with no offset/length",
                 "/path/to/myfile.wav",
-                ParsedPath("/path/to/myfile.wav", start=0, frames=-1, zip_offset=0, zip_length=-1)
+                ParsedPath(
+                    "/path/to/myfile.wav",
+                    start=0,
+                    frames=-1,
+                    zip_offset=0,
+                    zip_length=-1,
+                ),
             ),
             (
                 "wav file with offset & length",
                 "/path/to/myfile.wav:123:456",
-                ParsedPath("/path/to/myfile.wav", start=123, frames=456, zip_offset=0, zip_length=-1)
+                ParsedPath(
+                    "/path/to/myfile.wav",
+                    start=123,
+                    frames=456,
+                    zip_offset=0,
+                    zip_length=-1,
+                ),
             ),
             (
                 "zip file with no offset/length",
                 "/path/to/myfile.zip",
-                ParsedPath("/path/to/myfile.zip", start=0, frames=-1, zip_offset=0, zip_length=-1)
+                ParsedPath(
+                    "/path/to/myfile.zip",
+                    start=0,
+                    frames=-1,
+                    zip_offset=0,
+                    zip_length=-1,
+                ),
             ),
             (
                 "zip file with offset & length",
                 "/path/to/myfile.zip:123:456",
-                ParsedPath("/path/to/myfile.zip", start=0, frames=-1, zip_offset=123, zip_length=456)
+                ParsedPath(
+                    "/path/to/myfile.zip",
+                    start=0,
+                    frames=-1,
+                    zip_offset=123,
+                    zip_length=456,
+                ),
             ),
         ]
 
@@ -66,13 +90,13 @@ class TestDatasetOffsetsAndLengths(unittest.TestCase):
             "/path/to/myfile1.wav:123:456\t456",
             "/path/to/myfile2.wav\t456",
             "/path/to/myfile1.zip:123:456\t456",
-            "/path/to/myfile2.zip\t456"
+            "/path/to/myfile2.zip\t456",
         ]
         expected_data = [
-            TEST_SEQUENCE[123:123+456],
+            TEST_SEQUENCE[123 : 123 + 456],
             TEST_SEQUENCE,
             TEST_SEQUENCE[:206],
-            TEST_SEQUENCE
+            TEST_SEQUENCE,
         ]
 
         files["/dev/null/train.tsv"] = os.linesep.join(manifest_text)
@@ -83,7 +107,9 @@ class TestDatasetOffsetsAndLengths(unittest.TestCase):
             for item, expected_sequence in zip(dataset, expected_data):
                 filename = dataset.fnames[item["id"]]
                 with self.subTest(filename):
-                    numpy.testing.assert_almost_equal(item["source"].numpy(), expected_sequence, decimal=4)
+                    numpy.testing.assert_almost_equal(
+                        item["source"].numpy(), expected_sequence, decimal=4
+                    )
 
     def test_file_audio_dataset_zip_with_offsets_etc(self):
         files = {
@@ -103,10 +129,13 @@ class TestDatasetOffsetsAndLengths(unittest.TestCase):
         ]
         expected = [
             ("wav file, no offset, should return what we give it.", TEST_SEQUENCE),
-            ("wav file with offset 123, length 456", TEST_SEQUENCE[123:123 + 456]),
-            ("wav file with offset 456, length 789", TEST_SEQUENCE[456:456 + 789]),
+            ("wav file with offset 123, length 456", TEST_SEQUENCE[123 : 123 + 456]),
+            ("wav file with offset 456, length 789", TEST_SEQUENCE[456 : 456 + 789]),
             ("zip file with no offset/length", TEST_SEQUENCE),
-            ("zip file provides *byte* offset & length. Will cut off wav files longer than that.", TEST_SEQUENCE[:206]),
+            (
+                "zip file provides *byte* offset & length. Will cut off wav files longer than that.",
+                TEST_SEQUENCE[:206],
+            ),
         ]
 
         files["/dev/null/train.tsv"] = os.linesep.join(manifest_text)
@@ -117,7 +146,9 @@ class TestDatasetOffsetsAndLengths(unittest.TestCase):
 
             for item, (message, expected_sequence) in zip(dataset, expected):
                 with self.subTest(message):
-                    numpy.testing.assert_almost_equal(item["source"].numpy().flatten(), expected_sequence, decimal=4)
+                    numpy.testing.assert_almost_equal(
+                        item["source"].numpy().flatten(), expected_sequence, decimal=4
+                    )
 
     def test_get_features_or_waveform(self):
         files = {
@@ -136,12 +167,12 @@ class TestDatasetOffsetsAndLengths(unittest.TestCase):
             (
                 "wav file with offset 123, length 456",
                 "/path/to/myfile2.wav:123:456",
-                TEST_SEQUENCE[123:123+456],
+                TEST_SEQUENCE[123 : 123 + 456],
             ),
             (
                 "wav file with offset 456, length 789",
                 "/path/to/myfile3.wav:456:789",
-                TEST_SEQUENCE[456:456+789],
+                TEST_SEQUENCE[456 : 456 + 789],
             ),
             (
                 "zip file with no offset/length",
@@ -158,8 +189,12 @@ class TestDatasetOffsetsAndLengths(unittest.TestCase):
         with mock_files(files):
             for message, filename_unparsed, expected_sequence in test_cases:
                 with self.subTest(message):
-                    features = get_features_or_waveform(filename_unparsed, need_waveform=True)
-                    numpy.testing.assert_almost_equal(expected_sequence, features.flatten(), decimal=4)
+                    features = get_features_or_waveform(
+                        filename_unparsed, need_waveform=True
+                    )
+                    numpy.testing.assert_almost_equal(
+                        expected_sequence, features.flatten(), decimal=4
+                    )
 
 
 def encode_as_wav(x, sample_rate=SAMPLE_RATE, pad_zip=0):
@@ -171,10 +206,9 @@ def encode_as_wav(x, sample_rate=SAMPLE_RATE, pad_zip=0):
 
 @contextlib.contextmanager
 def mock_files(file_dict: Dict[str, Union[bytes, str]]):
-
-    def builtins_open(file, mode='r', *args, **kwargs):
+    def builtins_open(file, mode="r", *args, **kwargs):
         data = file_dict[file]
-        if 'b' not in mode and isinstance(data, bytes):
+        if "b" not in mode and isinstance(data, bytes):
             data = data.decode()
         mo = mock_open(read_data=data)
         mo.return_value.fileno.return_value = file
@@ -188,10 +222,15 @@ def mock_files(file_dict: Dict[str, Union[bytes, str]]):
     def mmap_mmap(file, *args, **kwargs):
         return MagicMock(**{"__enter__.return_value": file_dict[file]})
 
-    with patch("soundfile.read", side_effect=soundfile_read) as mock_soundfile_read, \
-         patch("os.path.isfile", return_value=True) as mock_isfile, \
-         patch("builtins.open", side_effect=builtins_open) as mock_builtins_open, \
-         patch("mmap.mmap", side_effect=mmap_mmap) as mock_mmap:
+    with patch(
+        "soundfile.read", side_effect=soundfile_read
+    ) as mock_soundfile_read, patch(
+        "os.path.isfile", return_value=True
+    ) as mock_isfile, patch(
+        "builtins.open", side_effect=builtins_open
+    ) as mock_builtins_open, patch(
+        "mmap.mmap", side_effect=mmap_mmap
+    ) as mock_mmap:
 
         assert open is mock_builtins_open
         assert os.path.isfile is mock_isfile
@@ -200,5 +239,5 @@ def mock_files(file_dict: Dict[str, Union[bytes, str]]):
         yield
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
    I tried, but it's been in triage for a while:
    https://github.com/pytorch/fairseq/issues/3962

- [X] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?

- [ ] Did you make sure to update the docs?
    I couldn't find any existing manifest instructions to update, or a particularly good place to do so

- [X] Did you write any new necessary tests?

## What does this PR do?

In this pull request, offset and number of frames can be optionally added to the path column of a manifest for .wav files, following the precedent of a similar feature for .zip files.

Previously, fairseq assumed .wav files would always be read in their entirety. This assumes that audio is already segmented prior to training, which can be very time- and space-consuming, especially when a data set's segmentation isn't fixed. It also opens up opportunities to quickly re-segment audio files which are longer than `max_sample_size` (which are otherwise truncated by fairseq).

Example manifest:
_(Note: To preserve backward compatibility, the final column the manifest does not affect how files are loaded.)_

```
/audio/files
/path/to/audio1.wav:0:16000    16000              # (new format) audio1.wav, frames 0 through 16000
/path/to/audio1.wav:32000:16000    16000          # (new format) audio1.wav, frames 32000 through 48000
/path/to/audio2.wav    16000                      # (existing format, bw compatible) audio2.wav, frames 0 through end
/path/to/collection1.zip:5000:10000    64000      # (existing format, bw compatible) collection1.zip, bytes 5000 through 10000, frames 0 through end  
```

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
✔
