### PR TITLE
Best metric is now only logged for the first of all the validation subsets

### DIFF
--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -438,7 +438,7 @@ def validate(
 
     trainer.begin_valid_epoch(epoch_itr.epoch)
     valid_losses = []
-    for subset in subsets:
+    for subset_idx, subset in enumerate(subsets):
         logger.info('begin validation on "{}" subset'.format(subset))
 
         # Initialize data iterator
@@ -481,7 +481,9 @@ def validate(
                 trainer.valid_step(sample)
 
         # log validation stats
-        stats = get_valid_stats(cfg, trainer, agg.get_smoothed_values())
+        # only tracking the best metric on the 1st validation subset
+        tracking_best = subset_idx == 0
+        stats = get_valid_stats(cfg, trainer, agg.get_smoothed_values(), tracking_best)
 
         if hasattr(task, "post_validate"):
             task.post_validate(trainer.get_model(), stats, agg)
@@ -493,10 +495,10 @@ def validate(
 
 
 def get_valid_stats(
-    cfg: DictConfig, trainer: Trainer, stats: Dict[str, Any]
+    cfg: DictConfig, trainer: Trainer, stats: Dict[str, Any], tracking_best: bool,
 ) -> Dict[str, Any]:
     stats["num_updates"] = trainer.get_num_updates()
-    if hasattr(checkpoint_utils.save_checkpoint, "best"):
+    if tracking_best and hasattr(checkpoint_utils.save_checkpoint, "best"):
         key = "best_{0}".format(cfg.checkpoint.best_checkpoint_metric)
         best_function = max if cfg.checkpoint.maximize_best_checkpoint_metric else min
         stats[key] = best_function(

--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -495,7 +495,10 @@ def validate(
 
 
 def get_valid_stats(
-    cfg: DictConfig, trainer: Trainer, stats: Dict[str, Any], tracking_best: bool,
+    cfg: DictConfig,
+    trainer: Trainer,
+    stats: Dict[str, Any],
+    tracking_best: bool,
 ) -> Dict[str, Any]:
     stats["num_updates"] = trainer.get_num_updates()
     if tracking_best and hasattr(checkpoint_utils.save_checkpoint, "best"):


### PR DESCRIPTION
Best metric is now only logged for the first of all the validation subsets

# Before submitting

- [x ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  * https://groups.google.com/g/fairseq-users/c/7nk3rJmvlg8
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fixes #4162

[2022-01-18 05:41:02,006][fairseq_cli.train][INFO] - begin validation on "test" subset
[2022-01-18 05:43:26,995][test][INFO] -
 {"epoch": 150, "test_loss": "24.118", "test_ntokens": "674.778", "test_nsentences": "13.3364",
  "test_nll_loss": "0.477", "test_uer": "7.599", "test_wer": "22.706", "test_raw_wer": "22.706",
  "test_wps": "1999.9", "test_wpb": "674.8", "test_bsz": "13.3", "test_num_updates": "20000",
  "test_best_wer": "14.46"}

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
