### PR TITLE
Adding scalar quantization aware training support for the hf_gpt2 model

### DIFF
--- a/fairseq/models/huggingface/hf_gpt2.py
+++ b/fairseq/models/huggingface/hf_gpt2.py
@@ -9,13 +9,13 @@ import sys
 from typing import Dict, List, Optional
 
 import torch
+
 from fairseq.models import (
     FairseqIncrementalDecoder,
     FairseqLanguageModel,
     register_model,
     register_model_architecture,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +44,14 @@ class HuggingFaceGPT2LanguageModel(FairseqLanguageModel):
         parser.add_argument('--attention-dropout', type=float, metavar='D',
                             help='dropout probability for attention weights')
         # fmt: on
+
+        # Adding argument for scalar quantization noise, same name as in transformer_lm model cfg
+        parser.add_argument(
+            "--quant_noise_scalar",
+            type=float,
+            metavar="D",
+            help="scalar quantization noise and scalar quantization at training time",
+        )
 
     @classmethod
     def build_model(cls, args, task):
@@ -142,6 +150,8 @@ def default_architecture(args):
     args.num_layers = getattr(args, "num_layers", 12)
     args.dropout = getattr(args, "dropout", 0.1)
     args.attention_dropout = getattr(args, "attention_dropout", 0.1)
+    # Adding argument for scalar quantization noise, same name as in transformer_lm model cfg
+    args.quant_noise_scalar = getattr(args, "quant_noise_scalar", 0.0)
 
 
 @register_model_architecture("hf_gpt2", "hf_gpt2_medium")

--- a/fairseq/modules/quantization/scalar/modules/__init__.py
+++ b/fairseq/modules/quantization/scalar/modules/__init__.py
@@ -5,5 +5,6 @@
 
 from .qact import ActivationQuantizer  # NOQA
 from .qconv import IntConv2d  # NOQA
+from .qconv1dhf import IntConv1DHF  # NOQA
 from .qemb import IntEmbedding  # NOQA
 from .qlinear import IntLinear  # NOQA

--- a/fairseq/modules/quantization/scalar/modules/qconv1dhf.py
+++ b/fairseq/modules/quantization/scalar/modules/qconv1dhf.py
@@ -1,0 +1,114 @@
+import torch
+import torch.nn as nn
+
+from fairseq.modules.quantization.scalar.ops import emulate_int
+
+# For IntConv1DHF, we take the same structure as the traditional Conv1D
+# but add elements for quantization from fairseq
+
+
+class IntConv1DHF(nn.Module):
+    """
+    Quantized counterpart of the Conv1D module that applies QuantNoise during training.
+    The Conv1D is a 1D-convolutional layer as defined by Radford et al. for OpenAI GPT (and also used in GPT-2).
+    Basically works like a linear layer but the weights are transposed.
+
+    Args:
+        - nf (int): The number of output features.
+        - nx (int): The number of input features.
+        - bias: bias or not
+        - p: amount of noise to inject (0 = no quantization, 1 = quantize all the weights)
+        - bits: number of bits
+        - method: choose among {"tensor", "histogram", "channel"}
+        - update_step: recompute scale and zero_point every update_steps iterations
+
+    Remarks:
+        - We use the straight-through estimator so that the gradients
+          back-propagate nicely in the network, this is implemented with
+          the detach() trick.
+        - Parameters scale and zero_point are recomputed every update_step
+          forward pass to reduce the overhead
+        - At test time, the weights are fully quantized
+    """
+
+    def __init__(
+        self,
+        nf,
+        nx,
+        bias=True,
+        p=0,
+        update_step=3000,
+        bits=8,
+        method="histogram",
+    ):
+        super().__init__()
+        self.nf = nf
+        w = torch.empty(nx, nf)
+        nn.init.normal_(w, std=0.02)
+        self.weight = nn.Parameter(w)
+        self.chosen_bias = bias
+        if self.chosen_bias:
+            self.bias = nn.Parameter(torch.zeros(nf))
+        else:
+            self.register_parameter("bias", None)
+
+        # quantization parameters
+        self.p = p
+        self.bits = bits
+        self.method = method
+        self.update_step = update_step
+        self.counter = 0
+
+    def forward(self, x):
+        # train with QuantNoise and evaluate the fully quantized network
+        p = self.p if self.training else 1
+
+        # update parameters every 100 iterations
+        if self.counter % self.update_step == 0:
+            self.scale = None
+            self.zero_point = None
+        self.counter += 1
+
+        # quantize weight
+        weight_quantized, self.scale, self.zero_point = emulate_int(
+            self.weight.detach(),
+            bits=self.bits,
+            method=self.method,
+            scale=self.scale,
+            zero_point=self.zero_point,
+        )
+
+        # mask to apply noise
+        mask = torch.zeros_like(self.weight)
+        mask.bernoulli_(1 - p)
+        noise = (weight_quantized - self.weight).masked_fill(mask.bool(), 0)
+
+        # using straight-through estimator (STE)
+        clamp_low = -self.scale * self.zero_point
+        clamp_high = self.scale * (2 ** self.bits - 1 - self.zero_point)
+        weight = (
+            torch.clamp(self.weight, clamp_low.item(), clamp_high.item())
+            + noise.detach()
+        )
+
+        # The forward for Conv1D is different from the Linear one
+        # https://github.com/huggingface/transformers/src/transformers/modeling_utils.py#L1764
+
+        size_out = x.size()[:-1] + (self.nf,)
+        x = torch.addmm(
+            self.bias, x.view(-1, x.size(-1)), weight
+        )  # weight, not self.weight
+        x = x.view(*size_out)
+        return x
+
+    def extra_repr(self):
+        return "nf={}, bias={}, quant_noise={}, bits={}, method={}".format(
+            self.nf,
+            self.bias is not None,
+            self.p,
+            self.bits,
+            self.method,
+        )
+
+
+# End


### PR DESCRIPTION
# Before submitting

- [No] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [Yes] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [Yes, comments around changes and help for the new flag] Did you make sure to update the docs?
- [Yes, the wikitext-103 language modelling example under scalar quant noise can now be used with the `--arch` hf_gpt2 ] Did you write any new necessary tests?

```
BASE_DIR=<BASE_DIR>
MAX_TOKENS=1024
CUDA_VISIBLE_DEVICES=0,1 fairseq-train \
  --task language_modeling $BASE_DIR/data-bin/wikitext-103 \
  --save-dir $BASE_DIR/hf_gpt2_wikitext-103/checkpoints \
  --arch hf_gpt2 \
  --dropout 0.1 \
  --optimizer adam --adam-betas '(0.9, 0.98)' \
  --weight-decay 0.01 --clip-norm 0.0 \
  --lr 0.0005 --lr-scheduler inverse_sqrt \
  --warmup-updates 4000 --warmup-init-lr 1e-07 \
  --tokens-per-sample 512 --sample-break-mode none \
  --max-tokens $MAX_TOKENS --update-freq 16 \
  --fp16 \
  --max-update 5000000 \
  --tensorboard-logdir $BASE_DIR/hf_gpt2_wikitext-103/tensorboard \
  --no-epoch-checkpoints \
  --quant-noise-scalar 0.5
```

Also, as an experiment we tried setting up 2 (almost) identical `transformer_lm` and `hf_gpt2` tiny models and trained them on the same dataset for 100k epochs.
 
We see that the models with noise have slightly worse validation losses than those without noise, and also that they take slightly longer to train: 

![tlm_w_wo_noise](https://user-images.githubusercontent.com/34727495/151883091-5ac599be-2c2f-4132-9259-96f78bad09f6.png)

![hf_gpt2_w_wo_noise](https://user-images.githubusercontent.com/34727495/151883106-4beac6dc-0120-4b90-bdcd-e92fdeb509bf.png)

## What does this PR do?
This PR adds support for (scalar) quantization aware training of the `hf_gpt2` model (which is a wrapper around the hugginface `GPT2LMHead` model ).

We add the `--quant-noise-scalar` flag as an argument to the `hf_gpt2` model (as is typically used for scalar noise in fairseq models). The model then gets quantized during the `<fairseq_task>.build_model()` phase.

The quantization replaces (in-place) existing modules with their quantized counterparts. To that end, we introduce a new quantized module `qconv1dhf` which replaces the `conv1d` modules in the hf_gpt2 model (similar to what `qlinear` does for the `nn.Linear` module).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Ofcourse !
