### PR TITLE
Use absolute path in scripts

### DIFF
--- a/examples/roberta/README.pretraining.md
+++ b/examples/roberta/README.pretraining.md
@@ -48,7 +48,7 @@ fairseq-preprocess \
 
 ### 2) Train RoBERTa base
 ```bash
-DATA_DIR=data-bin/wikitext-103
+DATA_DIR=$(pwd)/data-bin/wikitext-103
 
 fairseq-hydra-train -m --config-dir examples/roberta/config/pretraining \
 --config-name base task.data=$DATA_DIR


### PR DESCRIPTION
The script with relative paths raises an error of "No such file or directory: data-bin/wikitext-103/dict.txt" in `fairseq-hydra-train`.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, **doc improvements**)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
The script with relative paths raises an error of "No such file or directory: data-bin/wikitext-103/dict.txt" in `fairseq-hydra-train`.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
