### PR TITLE
remove unused arguments

### DIFF
--- a/fairseq/models/hubert/hubert.py
+++ b/fairseq/models/hubert/hubert.py
@@ -335,7 +335,7 @@ class HubertModel(BaseFairseqModel):
         model = HubertModel(cfg, task.cfg, task.dictionaries)
         return model
 
-    def apply_mask(self, x, padding_mask, target_list):
+    def apply_mask(self, x, padding_mask):
         B, T, C = x.shape
         if self.mask_prob > 0:
             mask_indices = compute_mask_indices(
@@ -454,7 +454,7 @@ class HubertModel(BaseFairseqModel):
         unmasked_features = self.dropout_features(unmasked_features)
 
         if mask:
-            x, mask_indices = self.apply_mask(features, padding_mask, target_list)
+            x, mask_indices = self.apply_mask(features, padding_mask)
         else:
             x = features
             mask_indices = None


### PR DESCRIPTION
Is it possible to remove this unused argument "target_list"?
or are there any special reasons so we have to keep it?