### PR TITLE
Remove redundant GPU syncs in Transformer encoder

### DIFF
--- a/fairseq/models/transformer/transformer_encoder.py
+++ b/fairseq/models/transformer/transformer_encoder.py
@@ -203,7 +203,7 @@ class TransformerEncoderBase(FairseqEncoder):
         """
         # compute padding mask
         encoder_padding_mask = src_tokens.eq(self.padding_idx)
-        has_pads = src_tokens.device.type == "xla" or encoder_padding_mask.any()
+        has_pads = bool(src_tokens.device.type == "xla" or encoder_padding_mask.any())
 
         x, encoder_embedding = self.forward_embedding(src_tokens, token_embeddings)
 


### PR DESCRIPTION
## What does this PR do?
When running on a GPU, `has_pads` is a GPU Tensor. (Unless we're running with XLA.) However it is implicitly used as a Python bool for control flow; this has the unfortunate effect of recomputing it for every layer when Python implicitly calls `bool()`. The big issue is that this triggers a sync and D2H copy, even though the value doesn't change. This PR just forces evaluation at the start so we don't unnecessarily sync after each layer. I discovered this when looking at FAMBench XLMR; it's not a huge change, but it saves a couple percent which isn't bad for such a modest delta.

## Did you have fun?
This one was quite tricky to actually run down, but very satisfying once I did. I'm working on better source tracking for the PyTorch profiler, so hopefully the experience will improve for users trying to understand these sorts of things in their own models.

CC @Mortimerp9 @myleott