### PR TITLE
[Data2Vec] loading data2vec checkpoitns for audio

### DIFF
--- a/fairseq/tasks/audio_finetuning.py
+++ b/fairseq/tasks/audio_finetuning.py
@@ -44,6 +44,9 @@ def label_len_fn(label):
 
 @dataclass
 class AudioFinetuningConfig(AudioPretrainingConfig):
+    cache_in_scratch: bool = field(
+        default=False, metadata={"help": "Whether to cache model in scratch."}
+    )
     # Options for reporting WER metrics during validation. Only applicable to
     # Seq2Seq models during fine-tuning
     eval_wer: bool = field(


### PR DESCRIPTION
Currently loading the data2vec audio checkpoints: https://github.com/pytorch/fairseq/tree/main/examples/data2vec#speech results in a missing parameter value of the omega config.

This PR is solves the problem by adding the parameter. Not sure if this is the correct way to deal with it though. 

cc @alexeib 