### PR TITLE
fix some bugs in MMA/waitk training and inference.

### DIFF
--- a/examples/simultaneous_translation/modules/fixed_pre_decision.py
+++ b/examples/simultaneous_translation/modules/fixed_pre_decision.py
@@ -128,7 +128,7 @@ def fixed_pooling_monotonic_attention(monotonic_attention):
                     ) < key_pool.size(0):
                         key_pool = key_pool[:-1]
                         if key_padding_mask_pool is not None:
-                            key_padding_mask_pool = key_padding_mask_pool[:-1]
+                            key_padding_mask_pool = key_padding_mask_pool[:, :-1]
 
                 p_choose_pooled = self.p_choose_from_qk(
                     query,

--- a/examples/simultaneous_translation/utils/monotonic_attention.py
+++ b/examples/simultaneous_translation/utils/monotonic_attention.py
@@ -86,7 +86,8 @@ def expected_soft_attention(
     if padding_mask is not None:
         alpha = alpha.masked_fill(padding_mask.unsqueeze(1), 0.0)
         soft_energy = soft_energy.masked_fill(
-            padding_mask.unsqueeze(1), -float("inf")
+            padding_mask.unsqueeze(1),
+            -1e4 if soft_energy.dtype == torch.float16 else -1e8
         )
 
     prob_check(alpha)
@@ -172,8 +173,7 @@ def mass_preservation(
         src_lens = src_len - padding_mask.sum(dim=1, keepdim=True)
         src_lens = src_lens.expand(-1, tgt_len).contiguous()
         # add back the last value
-        residuals += alpha.gather(2, src_lens.unsqueeze(2) - 1)
-        alpha = alpha.scatter(2, src_lens.unsqueeze(2) - 1, residuals)
+        alpha = alpha.scatter_add(2, src_lens.unsqueeze(2) - 1, residuals)
 
         prob_check(alpha)
 

--- a/fairseq/criterions/label_smoothed_cross_entropy_latency_augmented.py
+++ b/fairseq/criterions/label_smoothed_cross_entropy_latency_augmented.py
@@ -166,15 +166,20 @@ class LatencyAugmentedLabelSmoothedCrossEntropyCriterion(
             .view(-1, tgt_len)
         )
 
+        target_lengths = (~target_padding_mask).sum(-1)
+        src_lengths = sample["net_input"]["src_lengths"]
+        if net_output[-1].encoder_padding_mask is not None:
+            # for speech, input length != encoded lengths
+            src_lengths = (~net_output[-1].encoder_padding_mask).sum(-1)
         src_lengths = (
-            sample["net_input"]["src_lengths"]
+            src_lengths
             .unsqueeze(1)
             .expand(bsz, num_layers * num_heads)
             .contiguous()
             .view(-1)
         )
         expected_latency = LATENCY_METRICS[self.latency_avg_type](
-            expected_delays, src_lengths, None, target_padding_mask=target_padding_mask
+            expected_delays, src_lengths, target_lengths, target_padding_mask=target_padding_mask
         )
 
         # 2.1 average expected latency of heads
@@ -199,7 +204,7 @@ class LatencyAugmentedLabelSmoothedCrossEntropyCriterion(
             expected_delays.view(bsz, -1, tgt_len).var(dim=1).mean(dim=1)
         )
         expected_delays_var = expected_delays_var.sum()
-        var_loss = self.latency_avg_weight * expected_delays_var
+        var_loss = self.latency_var_weight * expected_delays_var
 
         # 3. Final loss
         latency_loss = avg_loss + var_loss


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fixes #3892 #4001 #3880.

1. For speech translation, the `fixed-pre-decision-*` models modifies the `p_choose` function, but the training [code](https://github.com/pytorch/fairseq/blob/e55e094b969df89d43e68b797707ee8d3bac1c5a/examples/simultaneous_translation/modules/monotonic_multihead_attention.py#L289) directly calls `p_choose_from_qk`, ignoring this change. This causes the speech models to underperform.
2. bug in padding mask for fixed_predecision
3. in `monotonic_attention_process_infer`, `p_choose_i` is selected by gathering p_choose at dimension 1 (source dimension), so the index tensor `monotonic_step` should have the shape `head x 1` instead to fit the intended usage of gather. The original dimension `1 x head` is incorrect.
4. For speech, the latency loss's source lengths is incorrect, since the model may downsample the source.
5. The latency loss used the same weight for avg and var.
6. `-float("inf")` causes nan in probability for expected alignment, changing to `-1e4` or `-1e8` fixes this.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
