### PR TITLE
Use omegaconf to load S2T data config YAML

### DIFF
--- a/fairseq/data/audio/data_cfg.py
+++ b/fairseq/data/audio/data_cfg.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 from argparse import Namespace
+from omegaconf import OmegaConf
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -10,21 +11,16 @@ from fairseq.data import Dictionary
 
 
 def get_config_from_yaml(yaml_path: Path):
-    try:
-        import yaml
-    except ImportError:
-        print("Please install PyYAML: pip install PyYAML")
     config = {}
     if yaml_path.is_file():
         try:
-            with open(yaml_path) as f:
-                config = yaml.load(f, Loader=yaml.FullLoader)
+            config = OmegaConf.load(yaml_path)
         except Exception as e:
             raise Exception(f"Failed to load config from {yaml_path.as_posix()}: {e}")
     else:
         raise FileNotFoundError(f"{yaml_path.as_posix()} not found")
 
-    return config
+    return OmegaConf.to_container(config, resolve=True)
 
 
 class S2TDataConfig(object):


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Updates the [`get_config_from_yaml`](https://github.com/pytorch/fairseq/blob/0f078de343d985e0cba6a5c1dc8a6394698c95c7/fairseq/data/audio/data_cfg.py#L12-L27) function used by the [`speech_to_text`](https://github.com/pytorch/fairseq/blob/main/fairseq/tasks/speech_to_text.py) task to use [`omegaconf`](https://github.com/omry/omegaconf):

- This is the tool used by Hydra to manage configurations, which is currently used in Fairseq.
- It has useful features such as [environment variable interpolation](https://omegaconf.readthedocs.io/en/2.0_branch/usage.html#environment-variable-interpolation) by using the following format: `{env: MY_ENV_VARIABLE}`. *

---

\* This will need to be updated if ever Fairseq moves to omegaconf 2.1 -> https://github.com/omry/omegaconf/issues/573
https://github.com/pytorch/fairseq/blob/0f078de343d985e0cba6a5c1dc8a6394698c95c7/setup.py#L216