### PR TITLE
Implements multi-task classification prediction with the optional ability to ignore left out values

### DIFF
--- a/fairseq/criterions/multi_sentence_prediction.py
+++ b/fairseq/criterions/multi_sentence_prediction.py
@@ -1,0 +1,149 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+from dataclasses import dataclass, field
+from typing import Optional
+import torch
+import torch.nn.functional as F
+
+from fairseq import metrics
+from fairseq.criterions import FairseqCriterion, register_criterion
+from fairseq.dataclass import FairseqDataclass
+
+
+@dataclass
+class MultiSentencePredictionConfig(FairseqDataclass):
+    ignore_str: Optional[str] = field(default="",  metadata={"help": "str to ignore"})
+    classification_head_name: str = field(
+        default="sentence_classification_head",
+        metadata={"help": "name of the classification head to use"},
+    )
+    number_of_targets: int = field(default=-1,  metadata={"help": "number of the classification heads to use"})
+
+
+@register_criterion("multi_sentence_prediction", dataclass=MultiSentencePredictionConfig)
+class SentencePredictionCriterion(FairseqCriterion):
+    def __init__(self, cfg: MultiSentencePredictionConfig, task):
+        super().__init__(task)
+        self.classification_head_name: str = cfg.classification_head_name
+        self.number_of_targets: int = cfg.number_of_targets
+
+        self.ignore_index: int = (self.task.label_dictionary.index(cfg.ignore_str.strip()) if (
+            cfg.ignore_str is not None and len(cfg.ignore_str) > 0) else -100)
+        print(f"Ignoring Index {self.ignore_index} for string {cfg.ignore_str}")
+        assert self.number_of_targets > 0
+
+    def forward(self, model, sample, reduce=True):
+        """Compute the loss for the given sample.
+
+        Returns a tuple with three elements:
+        1) the loss
+        2) the sample size, which is used as the denominator for the gradient
+        3) logging outputs to display while training
+        """
+        aggregate_loss = 0
+        logging_output = {}
+        sample_size = None
+        for target_index in range(self.number_of_targets):
+            classification_head = f"{self.classification_head_name}{target_index}"
+            assert (
+                hasattr(model, "classification_heads")
+                and classification_head in model.classification_heads
+            ), f"model must provide correct head not {classification_head}"
+
+            logits, _ = model(
+                **sample["net_input"],
+                features_only=True,
+                classification_head_name=classification_head,
+            )
+            targets = sample["target"][str(target_index)].view(-1)
+            sample_size = targets.numel()
+
+            lprobs = F.log_softmax(logits, dim=-1, dtype=torch.float32)
+            task_loss = F.nll_loss(lprobs, targets, reduction="sum", ignore_index=self.ignore_index)
+
+            loss = task_loss
+            # mha & ffn regularization update
+            if (
+                hasattr(model.args, "mha_reg_scale_factor")
+                and model.args.mha_reg_scale_factor != 0.0
+            ):
+                mha_reg_loss = model._get_adaptive_head_loss()
+                loss += mha_reg_loss
+                logging_output.update({"mha_reg_loss": mha_reg_loss})
+            if (
+                hasattr(model.args, "ffn_reg_scale_factor")
+                and model.args.ffn_reg_scale_factor != 0.0
+            ):
+                ffn_reg_loss = model._get_adaptive_ffn_loss()
+                loss += ffn_reg_loss
+                logging_output.update({"ffn_reg_loss": ffn_reg_loss})
+
+            aggregate_loss += loss
+
+            preds = logits.argmax(dim=1)
+            logging_output[f"ncorrect_{target_index}"] = (preds == targets).sum()
+
+        logging_output.update(
+            {
+                "loss": aggregate_loss.data,
+                "ntokens": sample["ntokens"],
+                "nsentences": sample_size,
+                "sample_size": sample_size,
+            })
+        return aggregate_loss, sample_size, logging_output
+
+    @staticmethod
+    def reduce_metrics(logging_outputs) -> None:
+        """Aggregate logging outputs from data parallel training."""
+        loss_sum = sum(log.get("loss", 0) for log in logging_outputs)
+        ntokens = sum(log.get("ntokens", 0) for log in logging_outputs)
+        nsentences = sum(log.get("nsentences", 0) for log in logging_outputs)
+        sample_size = sum(log.get("sample_size", 0) for log in logging_outputs)
+        mha_reg_loss_sum = sum(log.get("mha_reg_loss", 0) for log in logging_outputs)
+        ffn_reg_loss_sum = sum(log.get("ffn_reg_loss", 0) for log in logging_outputs)
+
+        metrics.log_scalar(
+            "loss", loss_sum / sample_size / math.log(2), sample_size, round=3
+        )
+        if mha_reg_loss_sum:
+            metrics.log_scalar(
+                "mha_reg_loss",
+                mha_reg_loss_sum / sample_size / math.log(2),
+                sample_size,
+                round=3,
+            )
+        if ffn_reg_loss_sum:
+            metrics.log_scalar(
+                "ffn_reg_loss",
+                ffn_reg_loss_sum / sample_size / math.log(2),
+                sample_size,
+                round=3,
+            )
+        if sample_size != ntokens:
+            metrics.log_scalar(
+                "nll_loss", loss_sum / ntokens / math.log(2), ntokens, round=3
+            )
+
+        if len(logging_outputs) > 0:
+            current_index = 0
+            current_correct = f"ncorrect_{current_index}"
+            while current_correct in logging_outputs[0]:
+                ncorrect = sum(log.get(current_correct, 0) for log in logging_outputs)
+                metrics.log_scalar(
+                    f"accuracy_{current_index}", 100.0 * ncorrect / nsentences, nsentences, round=1
+                )
+                current_index += 1
+                current_correct = f"ncorrect_{current_index}"
+
+    @staticmethod
+    def logging_outputs_can_be_summed() -> bool:
+        """
+        Whether the logging outputs returned by `forward` can be summed
+        across workers prior to calling `reduce_metrics`. Setting this
+        to True will improves distributed training speed.
+        """
+        return True

--- a/fairseq/tasks/multi_sentence_prediction.py
+++ b/fairseq/tasks/multi_sentence_prediction.py
@@ -1,0 +1,263 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+
+import contextlib
+from dataclasses import dataclass, field
+from typing import Optional, List
+from omegaconf import MISSING, II, open_dict, OmegaConf
+
+import numpy as np
+from fairseq.data import (
+    ConcatSentencesDataset,
+    Dictionary,
+    IdDataset,
+    NestedDictionaryDataset,
+    NumelDataset,
+    NumSamplesDataset,
+    OffsetTokensDataset,
+    PrependTokenDataset,
+    RawLabelDataset,
+    RightPadDataset,
+    RollDataset,
+    SortDataset,
+    StripTokenDataset,
+    data_utils,
+)
+from fairseq.data.shorten_dataset import maybe_shorten_dataset
+from fairseq.tasks import FairseqDataclass, FairseqTask, register_task
+from fairseq.dataclass import ChoiceEnum
+
+
+logger = logging.getLogger(__name__)
+SHORTEN_METHOD_CHOICES = ChoiceEnum(["none", "truncate", "random_crop"])
+
+
+@dataclass
+class MultiSentencePredictionConfig(FairseqDataclass):
+    data: str = field(default=MISSING, metadata={"help": "path to data directory"})
+    num_classes: str = field(
+        default="[-1]",
+        metadata={"help": "number of classes per multi-target"},
+    )
+    init_token: Optional[int] = field(
+        default=None,
+        metadata={"help": "add token at the beginning of each batch item"},
+    )
+    separator_token: Optional[int] = field(
+        default=None,
+        metadata={"help": "add separator token between inputs"},
+    )
+    no_shuffle: bool = field(
+        default=False,
+    )
+    shorten_method: SHORTEN_METHOD_CHOICES = field(
+        default="none",
+        metadata={
+            "help": "if not none, shorten sequences that exceed tokens_per_sample"
+        },
+    )
+    shorten_data_split_list: str = field(
+        default="",
+        metadata={
+            "help": "comma-separated list of dataset splits to apply shortening to, "
+            'e.g., "train,valid" (default: all dataset splits)'
+        },
+    )
+    add_prev_output_tokens: bool = field(
+        default=False,
+        metadata={
+            "help": "add prev_output_tokens to sample, used for encoder-decoder arch"
+        },
+    )
+    max_positions: int = field(
+        default=512,
+        metadata={"help": "max tokens per example"},
+    )
+    classification_head_name: str = II("criterion.classification_head_name")
+    seed: int = II("common.seed")
+
+
+@register_task("multi_sentence_prediction", dataclass=MultiSentencePredictionConfig)
+class MultiSentencePredictionTask(FairseqTask):
+    """
+    Sentence (or sentence pair) prediction (classification or regression) task.
+
+    Args:
+        dictionary (Dictionary): the dictionary for the input of the task
+    """
+
+    def __init__(self, cfg, data_dictionary, label_dictionary, num_classes: List[int]):
+        super().__init__(cfg)
+        self.dictionary = data_dictionary
+        self._label_dictionary = label_dictionary
+        self.num_classes = num_classes
+
+    @classmethod
+    def load_dictionary(cls, filename):
+        """Load the dictionary from the filename
+
+        Args:
+            filename (str): the filename
+        """
+        dictionary = Dictionary.load(filename)
+        dictionary.add_symbol("<mask>")
+        return dictionary
+
+    @classmethod
+    def setup_task(cls, cfg, **kwargs):
+        assert len(cfg.num_classes) > 0, "Must set task.num_classes"
+        num_classes = list(map(int, cfg.num_classes[1:-1].split(",")))
+        logger.info(f"[number of targets]: {num_classes}")
+        for num_class in num_classes:
+            assert num_class > 0, "Must set task.num_classes"
+
+        # load data dictionary
+        data_dict = cls.load_dictionary(
+            os.path.join(cfg.data, "input0", "dict.txt"),
+        )
+        logger.info("[input] dictionary: {} types".format(len(data_dict)))
+
+        label_dict = cls.load_dictionary(
+            os.path.join(cfg.data, "label0", "dict.txt"),
+        )
+        logger.info("[label] dictionary: {} types".format(len(label_dict)))
+        return cls(cfg, data_dict, label_dict, num_classes)
+
+    def load_dataset(self, split, combine=False, **kwargs):
+        """Load a given dataset split (e.g., train, valid, test)."""
+
+        def get_path(key, split):
+            return os.path.join(self.cfg.data, key, split)
+
+        def make_dataset(key, dictionary):
+            split_path = get_path(key, split)
+
+            try:
+                dataset = data_utils.load_indexed_dataset(
+                    split_path,
+                    dictionary,
+                    combine=combine,
+                )
+            except Exception as e:
+                if "StorageException: [404] Path not found" in str(e):
+                    logger.warning(f"dataset {e} not found")
+                    dataset = None
+                else:
+                    raise e
+            return dataset
+
+        input0 = make_dataset("input0", self.source_dictionary)
+        assert input0 is not None, "could not find dataset: {}".format(
+            get_path("input0", split)
+        )
+        input1 = make_dataset("input1", self.source_dictionary)
+
+        if self.cfg.init_token is not None:
+            input0 = PrependTokenDataset(input0, self.cfg.init_token)
+
+        if input1 is None:
+            src_tokens = input0
+        else:
+            if self.cfg.separator_token is not None:
+                input1 = PrependTokenDataset(input1, self.cfg.separator_token)
+
+            src_tokens = ConcatSentencesDataset(input0, input1)
+
+        with data_utils.numpy_seed(self.cfg.seed):
+            shuffle = np.random.permutation(len(src_tokens))
+
+        src_tokens = maybe_shorten_dataset(
+            src_tokens,
+            split,
+            self.cfg.shorten_data_split_list,
+            self.cfg.shorten_method,
+            self.max_positions(),
+            self.cfg.seed,
+        )
+
+        dataset = {
+            "id": IdDataset(),
+            "net_input": {
+                "src_tokens": RightPadDataset(
+                    src_tokens,
+                    pad_idx=self.source_dictionary.pad(),
+                ),
+                "src_lengths": NumelDataset(src_tokens, reduce=False),
+            },
+            "nsentences": NumSamplesDataset(),
+            "ntokens": NumelDataset(src_tokens, reduce=True),
+        }
+
+        if self.cfg.add_prev_output_tokens:
+            prev_tokens_dataset = RightPadDataset(
+                RollDataset(src_tokens, 1),
+                pad_idx=self.dictionary.pad(),
+            )
+            dataset["net_input"].update(
+                prev_output_tokens=prev_tokens_dataset,
+            )
+        all_target_datasets = {}
+        for i, cur_dataset_size in enumerate(self.num_classes):
+            label_dataset = make_dataset(f"label{i}", self.label_dictionary)
+            cur_dataset = OffsetTokensDataset(
+                StripTokenDataset(
+                    label_dataset,
+                    id_to_strip=self.label_dictionary.eos(),
+                ),
+                offset=-self.label_dictionary.nspecial,
+            )
+            all_target_datasets[str(i)] = cur_dataset
+
+        dataset.update(target=all_target_datasets)
+        nested_dataset = NestedDictionaryDataset(
+            dataset,
+            sizes=[src_tokens.sizes],
+        )
+
+        if self.cfg.no_shuffle:
+            dataset = nested_dataset
+        else:
+            dataset = SortDataset(
+                nested_dataset,
+                # shuffle
+                sort_order=[shuffle],
+            )
+
+        logger.info("Loaded {0} with #samples: {1}".format(split, len(dataset)))
+
+        self.datasets[split] = dataset
+        return self.datasets[split]
+
+    def build_model(self, cfg, from_checkpoint=False):
+        from fairseq import models
+
+        with open_dict(cfg) if OmegaConf.is_config(cfg) else contextlib.ExitStack():
+            cfg.max_positions = self.cfg.max_positions
+
+        model = models.build_model(cfg, self, from_checkpoint)
+        for index, num_class in enumerate(self.num_classes):
+            classification_head = f"{cfg.classification_head_name}{index}"
+            logger.info(f"Adding classification_head {classification_head}")
+            model.register_classification_head(classification_head, num_classes=num_class)
+
+        return model
+
+    def max_positions(self):
+        return self.cfg.max_positions
+
+    @property
+    def source_dictionary(self):
+        return self.dictionary
+
+    @property
+    def target_dictionary(self):
+        return self.dictionary
+
+    @property
+    def label_dictionary(self):
+        return self._label_dictionary

--- a/scripts/compute_auc.py
+++ b/scripts/compute_auc.py
@@ -1,0 +1,48 @@
+from fairseq.models.bart import BARTModel
+from fairseq.data.data_utils import load_indexed_dataset
+from fairseq.data import Dictionary
+from sklearn.metrics import roc_auc_score, classification_report
+from tqdm import tqdm
+
+import os
+import torch
+
+# bbbp model = "/fsx-html2/armenag/chemical/checkpoints/ft.bart_large.sentpred.ms16.uf1.mu2296.dr0.1.atdr0.1.actdr0.0.wd0.01.adam.beta9999.eps1e-08.clip0.1.lr3e-05.warm367.fp16.ngpu8/"
+# dataset = "bbbp"
+
+# model = "/fsx-html2/armenag/chemical/checkpoints/ft_clintox.bart_large.sentpred.ms16.uf1.mu2296.dr0.1.atdr0.1.actdr0.0.wd0.01.adam.beta9999.eps1e-08.clip0.1.lr3e-05.warm367.fp16.ngpu8"
+# dataset = "clintox"
+
+model = "/fsx-html2/armenag/chemical/checkpoints/ft_tox21.bart_large.sentpred.ms16.uf1.mu2296.dr0.1.atdr0.1.actdr0.0.wd0.01.adam.beta9999.eps1e-08.clip0.1.lr3e-05.warm367.fp16.ngpu8/"
+dataset = "tox21"
+
+os.system(f"mkdir {model}/input0")
+os.system(f"mkdir {model}/label")
+
+os.system(f"cp /data/home/armenag/code/chem/evaluation_data/{dataset}/processed/input0/dict.txt {model}/input0/")
+os.system(f"cp /data/home/armenag/code/chem/evaluation_data/{dataset}/processed/label/dict.txt {model}/label/")
+
+bart = BARTModel.from_pretrained(model, checkpoint_file='checkpoint_last.pt', bpe="sentencepiece",
+                                 sentencepiece_model="/fsx-html2/armenag/chemical/tokenizer/chem.model")
+bart.eval()
+bart.cuda()
+
+input_dict = Dictionary.load(f"/data/home/armenag/code/chem/evaluation_data/{dataset}/processed/input0/dict.txt")
+input_dict.add_symbol("<mask>")
+target_dict = Dictionary.load(f"/data/home/armenag/code/chem/evaluation_data/{dataset}/processed/label/dict.txt")
+
+smiles = list(load_indexed_dataset(
+    f"/data/home/armenag/code/chem/evaluation_data/{dataset}/processed/input0/test", input_dict))
+targets = list(load_indexed_dataset(
+    f"/data/home/armenag/code/chem/evaluation_data/{dataset}/processed/label/test", target_dict))
+
+y_pred = []
+y = []
+for i, (smile, target) in tqdm(list(enumerate(zip(smiles, targets)))):
+    smile = torch.cat((torch.cat((torch.tensor([0]), smile[:126])), torch.tensor([2])))
+    target = target[0].item()
+    y_pred.append(bart.predict('sentence_classification_head', smile)[0][1].exp().item())
+    y.append(target - 4)
+
+print("ROC_AUC_SCORE: ", roc_auc_score(y, y_pred))
+print(classification_report(y, [int(x+0.5) for x in y_pred]))

--- a/scripts/process_moleculenet.py
+++ b/scripts/process_moleculenet.py
@@ -4,6 +4,8 @@ import pandas as pd
 import argparse
 import os
 
+EMPTY_INDEX = -1
+
 p = argparse.ArgumentParser(description=__doc__,
                             formatter_class=argparse.RawDescriptionHelpFormatter)
 
@@ -28,6 +30,10 @@ if args.filter:
     nan_value = float("NaN")
     data_frame.replace("", nan_value, inplace=True)
     data_frame.dropna(subset=[data_frame.columns[args.class_index], data_frame.columns[args.smile_index]], inplace=True)
+else:
+    data_frame.replace("", EMPTY_INDEX, inplace=True)
+    data_frame.fillna(EMPTY_INDEX, inplace=True)
+
 
 print(data_frame)
 

--- a/scripts/process_moleculenet.py
+++ b/scripts/process_moleculenet.py
@@ -1,0 +1,95 @@
+from sklearn.model_selection import train_test_split
+
+import pandas as pd
+import argparse
+import os
+
+p = argparse.ArgumentParser(description=__doc__,
+                            formatter_class=argparse.RawDescriptionHelpFormatter)
+
+p.add_argument("--input", help="input file", type=str)
+p.add_argument("--smile-index", type=int, required=True)
+p.add_argument("--class-index", type=int, required=True)
+
+p.add_argument("--delimiter", type=str, default=",")
+
+p.add_argument("--train-perc", type=float, default=0.8)
+p.add_argument("--valid-perc", type=float, default=0.1)
+p.add_argument("--test-perc", type=float, default=0.1)
+
+p.add_argument("--seed", type=int, default=42)
+p.add_argument("--filter", type=bool, default=False)
+
+args = p.parse_args()
+
+data_frame = pd.read_csv(args.input, delimiter=args.delimiter)
+
+if args.filter:
+    nan_value = float("NaN")
+    data_frame.replace("", nan_value, inplace=True)
+    data_frame.dropna(subset=[data_frame.columns[args.class_index], data_frame.columns[args.smile_index]], inplace=True)
+
+print(data_frame)
+
+smiles_data = list(map(str, data_frame.iloc[:, args.smile_index].tolist()))
+class_data = list(map(int, data_frame.iloc[:, args.class_index].tolist()))
+
+X_train, X_valid, y_train, y_valid = train_test_split(
+    smiles_data, class_data, test_size=args.valid_perc + args.test_perc, random_state=args.seed)
+X_valid, X_test, y_valid, y_test = train_test_split(
+    X_valid, y_valid, test_size=args.test_perc/(args.valid_perc + args.test_perc), random_state=args.seed)
+
+print(f"Train Length: {len(X_train)}")
+print(f"Valid Length: {len(X_valid)}")
+print(f"Test Length: {len(X_test)}")
+
+names = ["train", "valid", "test"]
+X_splits = []
+y_splits = []
+
+
+os.system("mkdir raw")
+os.system("mkdir tokenized")
+os.system("mkdir processed")
+
+# Write Raw Splits
+print("Writing Input Splits")
+for name, smiles in zip(names, (X_train, X_valid, X_test)):
+    new_path = "raw/" + args.input + "." + name + ".input"
+    X_splits.append(new_path)
+    with open(new_path, "w+") as f:
+        for smile in smiles:
+            f.write(f"{smile}\n")
+
+print("Writing Output Splits")
+for name, targets in zip(names, (y_train, y_valid, y_test)):
+    new_path = "raw/" + args.input + "." + name + ".target"
+    y_splits.append(new_path)
+    with open(new_path, "w+") as f:
+        for target in targets:
+            f.write(f"{str(target)}\n")
+
+# Tokenize Texts
+print("Tokenizing")
+splits = []
+for path in X_splits:
+    cur_path = path.replace('raw', 'tokenized')
+    splits.append(cur_path)
+    os.system(
+        f"python /data/home/armenag/code/chem/fairseq-py/scripts/spm_parallel.py --input {path} --outputs {cur_path} --model /fsx-html2/armenag/chemical/tokenizer/chem.model")
+
+X_splits = splits
+
+os.system(('fairseq-preprocess --only-source '
+           f'--trainpref "{X_splits[0]}" '
+           f'--validpref "{X_splits[1]}" '
+           f'--testpref "{X_splits[2]}" '
+           '--destdir "processed/input0" --workers 60 '
+           '--srcdict /fsx-html2/armenag/chemical/tokenizer/chem.vocab.fs'))
+os.system(('fairseq-preprocess '
+           '--only-source '
+           f'--trainpref "{y_splits[0]}" '
+           f'--validpref "{y_splits[1]}" '
+           f'--testpref "{y_splits[2]}" '
+           f'--destdir "processed/label" '
+           '--workers 60;)'))

--- a/scripts/spm_parallel.py
+++ b/scripts/spm_parallel.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import contextlib
+import sys
+import sentencepiece as spm
+from tqdm import tqdm
+
+from collections import Counter
+from multiprocessing import Pool
+
+
+def main():
+    """
+    Helper script to encode raw text with the GPT-2 BPE using multiple processes.
+
+    The encoder.json and vocab.bpe files can be obtained here:
+    - https://dl.fbaipublicfiles.com/fairseq/gpt2_bpe/encoder.json
+    - https://dl.fbaipublicfiles.com/fairseq/gpt2_bpe/vocab.bpe
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model", required=True, help="sentencepiece model to use for encoding"
+    )
+    parser.add_argument(
+        "--inputs",
+        nargs="+",
+        default=["-"],
+        help="input files to filter/encode",
+    )
+    parser.add_argument(
+        "--outputs",
+        nargs="+",
+        default=["-"],
+        help="path to save encoded outputs",
+    )
+    parser.add_argument(
+        "--keep-empty",
+        action="store_true",
+        help="keep empty lines",
+    )
+    parser.add_argument("--workers", type=int, default=90)
+    args = parser.parse_args()
+
+    assert len(args.inputs) == len(
+        args.outputs
+    ), "number of input and output paths should match"
+
+    with contextlib.ExitStack() as stack:
+        inputs = [
+            stack.enter_context(open(input, "r", encoding="utf-8"))
+            if input != "-"
+            else sys.stdin
+            for input in args.inputs
+        ]
+        outputs = [
+            stack.enter_context(open(output, "w", encoding="utf-8"))
+            if output != "-"
+            else sys.stdout
+            for output in args.outputs
+        ]
+
+        encoder = MultiprocessingEncoder(args)
+        pool = Pool(args.workers, initializer=encoder.initializer)
+        encoded_lines = pool.imap(encoder.encode_lines, zip(*inputs), 10000)
+
+        stats = Counter()
+        for i, (filt, enc_lines) in enumerate(encoded_lines, start=1):
+            if filt == "PASS":
+                for enc_line, output_h in zip(enc_lines, outputs):
+                    print(enc_line, file=output_h)
+            else:
+                stats["num_filtered_" + filt] += 1
+            if i % 100000 == 0:
+                print("processed {} lines".format(i), file=sys.stderr)
+
+        for k, v in stats.most_common():
+            print("[{}] filtered {} lines".format(k, v), file=sys.stderr)
+
+
+class MultiprocessingEncoder(object):
+    def __init__(self, args):
+        self.args = args
+
+    def initializer(self):
+        global bpe
+        bpe = spm.SentencePieceProcessor()
+        bpe.Load(self.args.model)
+
+    def encode(self, line):
+        global bpe
+        ids = bpe.EncodeAsPieces(line)
+        return list(map(str, ids))
+
+    def encode_lines(self, lines):
+        """
+        Encode a set of lines. All lines will be encoded together.
+        """
+        enc_lines = []
+        for line in lines:
+            line = line.strip()
+            if len(line) == 0 and not self.args.keep_empty:
+                return ["EMPTY", None]
+            tokens = self.encode(line)
+            enc_lines.append(" ".join(tokens))
+        return ["PASS", enc_lines]
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What does this PR do?

Implements multi-task classification prediction with the optional ability to ignore left out values.  To test both criterion and task should be set to `multi_sentence_prediction`.  `--num-classes = [3,3]` to the classes per prediction target, if has empty classes + 1, total number of targets `--number-of-targets = 2` and the string value of the value to ignore (not the index): `--ignore-str = -1`