### PR TITLE
[Non-autoregressive Transformer] Add GLAT, CTC, DS

### DIFF
--- a/fairseq/criterions/nat_loss.py
+++ b/fairseq/criterions/nat_loss.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
+import logging
 import math
 
 import torch
@@ -11,8 +11,10 @@ from fairseq import metrics, utils
 from fairseq.criterions import FairseqCriterion, register_criterion
 from fairseq.dataclass import FairseqDataclass
 from torch import Tensor
-
 from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
 
 
 @dataclass
@@ -28,6 +30,8 @@ class LabelSmoothedDualImitationCriterion(FairseqCriterion):
     def __init__(self, task, label_smoothing):
         super().__init__(task)
         self.label_smoothing = label_smoothing
+        self.blank_index = getattr(task.target_dictionary, "blank_index", None)
+        self.pad_idx = task.target_dictionary.pad()
 
     def _compute_loss(
         self, outputs, targets, masks=None, label_smoothing=0.0, name="loss", factor=1.0
@@ -74,6 +78,71 @@ class LabelSmoothedDualImitationCriterion(FairseqCriterion):
         loss = loss * factor
         return {"name": name, "loss": loss, "nll_loss": nll_loss, "factor": factor}
 
+    def _compute_ctc_loss(self, logits, prev_output_tokens, targets, label_smoothing=0.0, name="ctc-loss", factor=1.0):
+        """
+        This method computes the ctc loss based on the logits using the pytorch ctc loss.
+        It does the required transformations for the ctc loss and includes label smoothing.
+        """
+        target_mask = targets.ne(self.pad_idx)
+        logit_mask = prev_output_tokens.ne(self.pad_idx)
+        logit_lengths = (logit_mask.bool()).long().sum(1)
+
+        if len(targets.size()) == 1:
+            targets = targets.unsqueeze(0)
+            target_mask = target_mask.unsqueeze(0)
+        target_lengths = (target_mask.bool()).long().sum(1)
+
+        log_probs = logits.log_softmax(-1)  # B x T x N_classes
+        log_probs_T = log_probs.transpose(0, 1)  # T x B x N_classes, this kind of shape is required for ctc_loss
+        targets = targets[target_mask.bool()].long()
+        loss = F.ctc_loss(
+            log_probs_T.float(),
+            targets,
+            logit_lengths,
+            target_lengths,
+            blank=self.blank_index,
+            reduction="mean",
+            zero_infinity=True,
+        )
+
+        # The number of invalid samples are samples where the predictions are shorter than the targets.
+        # If this is true for too many samples, one might think about increasing --ctc-src-upsample-scale.
+        n_invalid_samples = (logit_lengths < target_lengths).long().sum()
+
+        if n_invalid_samples > 0:
+            logger.warning(
+                f"The length of predicted alignment is shorter than target length, increase upsample factor: {n_invalid_samples} samples"
+            )
+
+        if label_smoothing > 0:
+            smoothed_loss = -log_probs.mean(-1)[logit_mask.bool()].mean()
+            loss = (1 - label_smoothing) * loss + label_smoothing * smoothed_loss
+
+        return {"name": name, "loss": loss, "factor": factor}
+    
+    def _compute_ds_ctc_loss(self, logits, prev_output_tokens, targets, label_smoothing=0.0, name="ds-ctc-loss", factor=1.0):
+        logits = list(map(lambda layer_pred: layer_pred.squeeze(dim=0), torch.split(logits,1)))
+        ctc_losses = list(map(lambda layer_pred: self._compute_ctc_loss(
+            logits=layer_pred,
+            prev_output_tokens=prev_output_tokens,
+            targets=targets,
+            label_smoothing=label_smoothing
+        )['loss'], logits))
+
+        return {"name": name, "loss": sum(ctc_losses) / len(ctc_losses), "factor": factor}
+
+    def _compute_ds_loss(self, logits, targets, masks=None, label_smoothing=0.0, name="ds-loss", factor=1.0):
+        logits = list(map(lambda layer_pred: layer_pred.squeeze(dim=0), torch.split(logits,1)))
+        losses = list(map(lambda layer_pred: self._compute_loss(
+            outputs=layer_pred,
+            targets=targets,
+            masks=masks,
+            label_smoothing=label_smoothing
+        ), logits))
+        loss_mean = sum([loss['loss'] for loss in losses]) / len(losses)
+        nll_loss_mean = sum([loss['nll_loss'] for loss in losses]) / len(losses)
+        return {"name": name, "loss": loss_mean, "nll_loss": nll_loss_mean, "factor": factor}
+
     def _custom_loss(self, loss, name="loss", factor=1.0):
         return {"name": name, "loss": loss, "factor": factor}
 
@@ -97,8 +166,21 @@ class LabelSmoothedDualImitationCriterion(FairseqCriterion):
         losses, nll_loss = [], []
 
         for obj in outputs:
-            if outputs[obj].get("loss", None) is None:
-                _losses = self._compute_loss(
+            if obj.startswith('glat'):
+                continue
+            if obj.startswith('ctc'):
+                loss_function = self._compute_ctc_loss if not outputs[obj].get("deep_supervision") else self._compute_ds_ctc_loss
+                _losses = loss_function(
+                    outputs[obj].get("logits"),
+                    outputs[obj].get("prev_output_tokens"),
+                    outputs[obj].get("targets"),
+                    outputs[obj].get("ls", 0.0),
+                    name=obj + "-loss",
+                    factor=outputs[obj].get("factor", 1.0),
+                )
+            elif outputs[obj].get("loss", None) is None:
+                loss_function = self._compute_loss if not outputs[obj].get("deep_supervision") else self._compute_ds_loss
+                _losses = loss_function(
                     outputs[obj].get("out"),
                     outputs[obj].get("tgt"),
                     outputs[obj].get("mask", None),
@@ -131,7 +213,11 @@ class LabelSmoothedDualImitationCriterion(FairseqCriterion):
             "nsentences": nsentences,
             "sample_size": sample_size,
         }
+        if "glat_accu" in outputs:
+            logging_output["glat_accu"] = outputs['glat_accu']
 
+        if "glat_context_p" in outputs:
+            logging_output['glat_context_p'] = outputs['glat_context_p']
         for l in losses:
             logging_output[l["name"]] = (
                 utils.item(l["loss"].data / l["factor"])
@@ -149,16 +235,14 @@ class LabelSmoothedDualImitationCriterion(FairseqCriterion):
         )
         loss = utils.item(sum(log.get("loss", 0) for log in logging_outputs))
         nll_loss = utils.item(sum(log.get("nll_loss", 0) for log in logging_outputs))
+        glat_accu = utils.item(sum(log.get("glat_accu", 0) for log in logging_outputs))
+        glat_context_p = utils.item(sum(log.get("glat_context_p", 0) for log in logging_outputs))
 
-        metrics.log_scalar(
-            "loss", loss / sample_size / math.log(2), sample_size, round=3
-        )
-        metrics.log_scalar(
-            "nll_loss", nll_loss / sample_size / math.log(2), sample_size, round=3
-        )
-        metrics.log_derived(
-            "ppl", lambda meters: utils.get_perplexity(meters["loss"].avg)
-        )
+        metrics.log_scalar("loss", loss / sample_size / math.log(2), sample_size, round=3)
+        metrics.log_scalar("nll_loss", nll_loss / sample_size / math.log(2), sample_size, round=3)
+        metrics.log_derived("ppl", lambda meters: utils.get_perplexity(meters["loss"].avg))
+        metrics.log_scalar("glat_accu", glat_accu / sample_size, sample_size, round=3)
+        metrics.log_scalar("glat_context_p", glat_context_p / sample_size, sample_size, round=3)
 
         for key in logging_outputs[0]:
             if key[-5:] == "-loss":
@@ -177,4 +261,4 @@ class LabelSmoothedDualImitationCriterion(FairseqCriterion):
         across workers prior to calling `reduce_metrics`. Setting this
         to True will improves distributed training speed.
         """
-        return True
+        return False

--- a/fairseq/data/indexed_dataset.py
+++ b/fairseq/data/indexed_dataset.py
@@ -59,10 +59,10 @@ def infer_dataset_impl(path):
         return None
 
 
-def make_builder(out_file, impl, vocab_size=None):
+def make_builder(out_file, impl, vocab_size=None, dtype=None):
     if impl == "mmap":
         return MMapIndexedDatasetBuilder(
-            out_file, dtype=best_fitting_int_dtype(vocab_size)
+            out_file, dtype=dtype if dtype is not None else best_fitting_int_dtype(vocab_size)
         )
     elif impl == "fasta":
         raise NotImplementedError
@@ -71,7 +71,7 @@ def make_builder(out_file, impl, vocab_size=None):
             "Use HuffmanCodeBuilder directly as it has a different interface."
         )
     else:
-        return IndexedDatasetBuilder(out_file)
+        return IndexedDatasetBuilder(out_file, dtype)
 
 
 def make_dataset(path, impl, fix_lua_indexing=False, dictionary=None):

--- a/fairseq/models/nat/fairseq_nat_model.py
+++ b/fairseq/models/nat/fairseq_nat_model.py
@@ -108,6 +108,8 @@ class FairseqNATModel(TransformerModel):
 
         self.ensemble_models = None
 
+        self.update_num = 0
+
     @property
     def allow_length_beam(self):
         return False
@@ -115,6 +117,9 @@ class FairseqNATModel(TransformerModel):
     @property
     def allow_ensemble(self):
         return True
+
+    def set_num_updates(self, num_updates):
+        self.update_num = num_updates
 
     def enable_ensemble(self, models):
         self.encoder.ensemble_models = [m.encoder for m in models]

--- a/fairseq/models/nat/nonautoregressive_transformer.py
+++ b/fairseq/models/nat/nonautoregressive_transformer.py
@@ -2,16 +2,18 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
+import logging
+import copy
 import torch
 import torch.nn.functional as F
 from fairseq import utils
 from fairseq.iterative_refinement_generator import DecoderOut
 from fairseq.models import register_model, register_model_architecture
 from fairseq.models.nat import FairseqNATDecoder, FairseqNATModel, ensemble_decoder
-from fairseq.models.transformer import Embedding
+from fairseq.models.transformer import Embedding, base_architecture
 from fairseq.modules.transformer_sentence_encoder import init_bert_params
 
+logger = logging.getLogger(__name__)
 
 def _mean_pooling(enc_feats, src_masks):
     # enc_feats: T x B x C
@@ -42,6 +44,33 @@ def _uniform_assignment(src_lens, trg_lens):
 
 @register_model("nonautoregressive_transformer")
 class NATransformerModel(FairseqNATModel):
+
+    def __init__(self, args, encoder, decoder):
+        super().__init__(args, encoder, decoder)
+        self.use_glat = getattr(args, 'use_glat', False)
+        self.use_glat_with_nat_aux = getattr(args, 'use_glat_with_nat_aux', False)
+        self.use_ctc_decoder = getattr(args, 'use_ctc_decoder', False)
+        self.use_ctc_beam_decoder = getattr(args, 'use_ctc_beam_decoder', False)
+        self.use_deep_supervision = getattr(args, 'use_deep_supervision', False)
+
+        if self.use_ctc_beam_decoder:
+            from ctcdecode import CTCBeamDecoder
+            self.ctc_decoder = CTCBeamDecoder(decoder.dictionary.symbols,
+                                        model_path=None,
+                                        alpha=0,
+                                        beta=0,
+                                        cutoff_top_n=40,
+                                        cutoff_prob=1.0,
+                                        beam_width=args.ctc_beam_size,
+                                        num_processes=20,
+                                        blank_id=decoder.dictionary.blank_index,
+                                        log_probs_input=True)
+
+        if  self.use_glat_with_nat_aux and self.use_glat:
+            new_args = copy.deepcopy(args)
+            new_args.decoder_layers = args.glat_nat_aux_layers
+            self.aux_nat_decoder = self.build_decoder(new_args, self.decoder.dictionary, self.decoder.embed_tokens)
+
     @property
     def allow_length_beam(self):
         return True
@@ -49,12 +78,20 @@ class NATransformerModel(FairseqNATModel):
     @staticmethod
     def add_args(parser):
         FairseqNATModel.add_args(parser)
+        NATransformerModel.add_nat_transformer_model_args(parser)
 
-        # length prediction
+    @staticmethod
+    def add_nat_transformer_model_args(parser):
+        # fmt: off
         parser.add_argument(
             "--src-embedding-copy",
             action="store_true",
             help="copy encoder word embeddings as the initial input of the decoder",
+        )
+        parser.add_argument(
+            "--no-decoder-input-embedding",
+            action="store_true",
+            help="do not embed decoder input tokens",
         )
         parser.add_argument(
             "--pred-length-offset",
@@ -71,6 +108,52 @@ class NATransformerModel(FairseqNATModel):
             type=float,
             help="weights on the length prediction loss",
         )
+        parser.add_argument(
+            "--use-glat",
+            action="store_true",
+            help="enables glancing sampling from glancing transformers",
+        )
+        parser.add_argument(
+            "--use-glat-with-nat-aux",
+            action="store_true",
+            help="additionally uses a separate NAT model without GLAT as an auxiliariy loss, decoder is copied for that and re-initialized. This also requires --find-unused-parameters as the aux_decoder is not used during validation for producing the loss",
+        )
+        parser.add_argument(
+            "--glat-nat-aux-factor",
+            type=float,
+            help="only used when using --use-glat-with-nat-aux, sets the lambda of the additional auxiliary loss",
+        )
+        parser.add_argument(
+            "--glat-nat-aux-layers",
+            type=int,
+            help="only used when using --use-glat-with-nat-aux, sets the number of layers of the additional auxiliary decoder",
+        )
+        parser.add_argument(
+            "--use-ctc-decoder",
+            action='store_true',
+            help="enables the ctc decoding instead of using the length prediction",
+        )
+        parser.add_argument(
+            "--ctc-src-upsample-scale",
+            type=int,
+            help="how much the target length should be upsampled by",
+        )
+        parser.add_argument(
+            "--use-ctc-beam-decoder",
+            action='store_true',
+            help="whether CTC Beam search should be used",
+        )
+        parser.add_argument(
+            "--ctc-beam-size",
+            type=int,
+            help="beam size of the ctc decoder",
+        )
+        parser.add_argument(
+            "--use-deep-supervision",
+            action='store_true',
+            help="uses deep supervision from Huang et al., 2021 where we compute the loss at each decoder layer",
+        )
+        # fmt: on
 
     @classmethod
     def build_decoder(cls, args, tgt_dict, embed_tokens):
@@ -79,59 +162,179 @@ class NATransformerModel(FairseqNATModel):
             decoder.apply(init_bert_params)
         return decoder
 
-    def forward(
-        self, src_tokens, src_lengths, prev_output_tokens, tgt_tokens, **kwargs
-    ):
-        # encoding
-        encoder_out = self.encoder(src_tokens, src_lengths=src_lengths, **kwargs)
+    def get_ctc_target_tokens(self, tgt_tokens, prev_output_tokens, log_probs):
+        """
+        This method provides Viterbi aligned tgt_tokens that have the same length as the decoder inputs.
+        More info sec. 3.4: https://arxiv.org/pdf/2012.15833.pdf
+        """
+        
+        #TODO: This is C++ code from https://github.com/rosinality/imputer-pytorch/tree/master/torch_imputer that is not included in this PR
+        #      Up to Fairseq team to decide how they want to import and build it
+        from fairseq.models.nat.torch_imputer import best_alignment
+        nonpad_positions = tgt_tokens.ne(self.pad)
+        seq_lens = (nonpad_positions).sum(1)
+        output_masks = prev_output_tokens.ne(self.pad)
+        output_length = output_masks.sum(dim=-1)
+        log_probs_T = log_probs.transpose(0, 1).float()
+        best_aligns = best_alignment(log_probs_T, tgt_tokens, output_length, seq_lens, self.decoder.dictionary.blank_index, zero_infinity=True)
+        best_aligns_pad = torch.tensor([a + [(tgt_tokens.shape[1] - 1)*2] * (log_probs_T.size(0) - len(a)) for a in best_aligns], device=log_probs_T.device, dtype=tgt_tokens.dtype)
+        oracle_pos = best_aligns_pad.div(2, rounding_mode='trunc').clip(max=tgt_tokens.shape[1] - 1) # Needed from imputer-pytorch as seen in their get_symbol method
+        oracle = tgt_tokens.gather(-1, oracle_pos)
+        return oracle
 
-        # length prediction
-        length_out = self.decoder.forward_length(
-            normalize=False, encoder_out=encoder_out
-        )
-        length_tgt = self.decoder.forward_length_prediction(
-            length_out, encoder_out, tgt_tokens
-        )
+    @torch.no_grad()
+    def glancing_sampling(self, tgt_tokens, prev_output_tokens, encoder_out):
+        """
+        This implements the glancing sampling from "Glancing Transformer for Non-Autoregressive Neural Machine Translation" (Qian et al., 2021)
+        Paper: https://aclanthology.org/2021.acl-long.155/
+        """
 
-        # decoding
+        def update_glat_schedule(update_num, max_update):
+                train_ratio = max(0, min(1, update_num / max_update))
+                schedule = 0.5 - 0.2 * train_ratio
+                return schedule
+
+        glat_current_prob = update_glat_schedule(self.update_num, self.args.max_update)
+
         word_ins_out = self.decoder(
             normalize=False,
             prev_output_tokens=prev_output_tokens,
             encoder_out=encoder_out,
         )
 
-        return {
-            "word_ins": {
+        if self.use_ctc_decoder:
+            tgt_tokens = self.get_ctc_target_tokens(tgt_tokens, prev_output_tokens, F.log_softmax(word_ins_out, -1))
+
+        pred_tokens = word_ins_out.argmax(-1)
+        nonpad_positions = tgt_tokens.ne(self.pad)
+        seq_lens = (nonpad_positions).sum(1)
+        same_num = ((pred_tokens == tgt_tokens) & nonpad_positions).sum(1)
+        keep_prob = ((seq_lens - same_num) / seq_lens * glat_current_prob).unsqueeze(-1)
+        keep_word_mask = (torch.rand(prev_output_tokens.shape, device=word_ins_out.device) < keep_prob).bool()
+        glat_prev_output_tokens = prev_output_tokens.masked_fill(keep_word_mask, 0) + tgt_tokens.masked_fill(
+            ~keep_word_mask, 0)
+
+        glat_info = {
+            "glat_accu": (same_num.sum() / seq_lens.sum()).item(),
+            "glat_context_p": glat_current_prob,
+            "glat_keep": keep_prob.mean().item()
+        }
+
+        length_loss_mult = nonpad_positions.sum().item() / seq_lens.sum().item()
+
+        return glat_prev_output_tokens, glat_info, length_loss_mult
+
+    def nat_auxiliary_loss(self, tgt_tokens, prev_output_tokens, encoder_out):
+        """
+        This idea is taken from "The Volctrans GLAT System: Non-autoregressive Translation Meets WMT21" (Qian et al., 2021)
+        Paper: https://arxiv.org/pdf/2109.11247.pdf
+        """
+        aux_word_ins_out = self.aux_nat_decoder(
+            normalize=False,
+            prev_output_tokens=prev_output_tokens,
+            encoder_out=encoder_out,
+        )
+        aux_prediction_info = {
+            "out": aux_word_ins_out,
+            "tgt": tgt_tokens,
+            "mask": tgt_tokens.ne(self.pad),
+            "ls": self.args.label_smoothing,
+            "nll_loss": True,
+            "factor": self.args.glat_nat_aux_factor
+        }
+        return aux_prediction_info
+
+    def forward(self, src_tokens, src_lengths, prev_output_tokens, tgt_tokens, **kwargs):
+
+        ret = {}
+
+        # encoding
+        encoder_out = self.encoder(src_tokens, src_lengths=src_lengths, **kwargs)
+
+        # Target length based on either the length prediction or CTC
+        length_tgt, length_out = self.decoder.get_length_target(encoder_out, src_tokens, tgt_tokens, normalize=False)
+        length_loss_factor = self.decoder.length_loss_factor
+
+        if self.use_ctc_decoder:
+            prev_output_tokens_orig = prev_output_tokens
+            prev_output_tokens = self._get_initial_outputs(src_tokens, length_tgt)
+
+        # GLAT
+        if self.use_glat and tgt_tokens is not None:
+            if self.use_glat_with_nat_aux:
+                aux_prev_output_tokens = prev_output_tokens_orig if self.use_ctc_decoder else prev_output_tokens
+                aux_prediction_info = self.nat_auxiliary_loss(tgt_tokens, aux_prev_output_tokens, encoder_out)
+                ret["aux_nat"] = aux_prediction_info
+
+            prev_output_tokens, glat_info, length_mult = self.glancing_sampling(tgt_tokens, prev_output_tokens, encoder_out)
+            length_loss_factor = length_loss_factor * length_mult
+            ret.update(glat_info)
+
+        # decoding
+        word_ins_out = self.decoder(
+            normalize=False,
+            prev_output_tokens=prev_output_tokens,
+            encoder_out=encoder_out,
+            return_deep_supervision=self.use_deep_supervision
+        )
+
+        # Either add the CTC custom loss or populate with predictions to compute loss in nat_loss.py
+        if self.use_ctc_decoder:
+            ctc_info = {
+                "logits": word_ins_out,
+                "prev_output_tokens": prev_output_tokens,
+                "targets": tgt_tokens,
+                "ls": self.args.label_smoothing,
+                "deep_supervision": self.use_deep_supervision
+            }
+            ret["ctc"] = ctc_info
+        else:
+            length_info = {
+                "out": length_out,
+                "tgt": length_tgt,
+                "factor": length_loss_factor,
+            }
+            prediction_info = {
                 "out": word_ins_out,
                 "tgt": tgt_tokens,
                 "mask": tgt_tokens.ne(self.pad),
                 "ls": self.args.label_smoothing,
                 "nll_loss": True,
-            },
-            "length": {
-                "out": length_out,
-                "tgt": length_tgt,
-                "factor": self.decoder.length_loss_factor,
-            },
-        }
+                "deep_supervision": self.use_deep_supervision
+            }
+            ret["length"] = length_info
+            ret["word_ins"] = prediction_info
+
+        return ret
 
     def forward_decoder(self, decoder_out, encoder_out, decoding_format=None, **kwargs):
-        step = decoder_out.step
         output_tokens = decoder_out.output_tokens
-        output_scores = decoder_out.output_scores
         history = decoder_out.history
 
         # execute the decoder
         output_masks = output_tokens.ne(self.pad)
-        _scores, _tokens = self.decoder(
+        output_probs = self.decoder(
             normalize=True,
             prev_output_tokens=output_tokens,
             encoder_out=encoder_out,
-            step=step,
-        ).max(-1)
+            step=decoder_out.step,
+        )
 
-        output_tokens.masked_scatter_(output_masks, _tokens[output_masks])
-        output_scores.masked_scatter_(output_masks, _scores[output_masks])
+        if self.use_ctc_decoder and self.use_ctc_beam_decoder:
+            output_length = torch.sum(output_masks, dim=-1)
+            beam_results, beam_scores, timesteps, out_lens = self.ctc_decoder.decode(output_probs, output_length)
+            top_beam_tokens = beam_results[:, 0, :]
+            top_beam_len = out_lens[:, 0]
+            mask = torch.arange(0, top_beam_tokens.size(1)).type_as(top_beam_len).repeat(top_beam_len.size(0), 1).lt(top_beam_len.unsqueeze(1))
+            top_beam_tokens[~mask] = self.decoder.pad
+            output_tokens = top_beam_tokens.to(output_probs.device)
+            output_scores = torch.full(top_beam_tokens.size(), 1.0)
+        else:
+            _scores, _tokens = output_probs.max(-1)
+            output_scores = decoder_out.output_scores
+            output_tokens.masked_scatter_(output_masks, _tokens[output_masks])
+            output_scores.masked_scatter_(output_masks, _scores[output_masks])
+
         if history is not None:
             history.append(output_tokens.clone())
 
@@ -142,28 +345,30 @@ class NATransformerModel(FairseqNATModel):
             history=history,
         )
 
-    def initialize_output_tokens(self, encoder_out, src_tokens):
-        # length prediction
-        length_tgt = self.decoder.forward_length_prediction(
-            self.decoder.forward_length(normalize=True, encoder_out=encoder_out),
-            encoder_out=encoder_out,
-        )
-
-        max_length = length_tgt.clamp_(min=2).max()
+    def _get_initial_outputs(self, src_tokens, length_tgt):
+        """
+        Returns a tensor of shape B x T where T is the maximum length target for the batch.
+        It will contain elements that have the structure:
+        self.bos, multiple self.unk up to target length, self.eos, multiple self.pad if needed
+        """
+        max_length = length_tgt.clamp_(min=2, max=self.args.max_target_positions).max()
         idx_length = utils.new_arange(src_tokens, max_length)
 
-        initial_output_tokens = src_tokens.new_zeros(
-            src_tokens.size(0), max_length
-        ).fill_(self.pad)
-        initial_output_tokens.masked_fill_(
-            idx_length[None, :] < length_tgt[:, None], self.unk
-        )
+        initial_output_tokens = src_tokens.new_zeros(src_tokens.size(0), max_length).fill_(self.pad)
+        initial_output_tokens.masked_fill_(idx_length[None, :] < length_tgt[:, None], self.unk)
         initial_output_tokens[:, 0] = self.bos
         initial_output_tokens.scatter_(1, length_tgt[:, None] - 1, self.eos)
+        return initial_output_tokens
 
-        initial_output_scores = initial_output_tokens.new_zeros(
-            *initial_output_tokens.size()
-        ).type_as(encoder_out["encoder_out"][0])
+    def initialize_output_tokens(self, encoder_out, src_tokens):
+        """
+        Initializes the DecoderOut scores and tokens with zeros and sentences containing self.unk.
+        This is used to simulate previous output tokens.
+        Currently this method only finds usage in the iterative_refinement_generator.py
+        """
+        length_tgt, _ = self.decoder.get_length_target(encoder_out, src_tokens, normalize=True)
+        initial_output_tokens = self._get_initial_outputs(src_tokens, length_tgt)
+        initial_output_scores = initial_output_tokens.new_zeros(*initial_output_tokens.size()).type_as(encoder_out["encoder_out"][0])
 
         return DecoderOut(
             output_tokens=initial_output_tokens,
@@ -177,59 +382,50 @@ class NATransformerModel(FairseqNATModel):
     def regenerate_length_beam(self, decoder_out, beam_size):
         output_tokens = decoder_out.output_tokens
         length_tgt = output_tokens.ne(self.pad).sum(1)
-        length_tgt = (
-            length_tgt[:, None]
-            + utils.new_arange(length_tgt, 1, beam_size)
-            - beam_size // 2
-        )
-        length_tgt = length_tgt.view(-1).clamp_(min=2)
-        max_length = length_tgt.max()
-        idx_length = utils.new_arange(length_tgt, max_length)
-
-        initial_output_tokens = output_tokens.new_zeros(
-            length_tgt.size(0), max_length
-        ).fill_(self.pad)
-        initial_output_tokens.masked_fill_(
-            idx_length[None, :] < length_tgt[:, None], self.unk
-        )
-        initial_output_tokens[:, 0] = self.bos
-        initial_output_tokens.scatter_(1, length_tgt[:, None] - 1, self.eos)
-
-        initial_output_scores = initial_output_tokens.new_zeros(
-            *initial_output_tokens.size()
-        ).type_as(decoder_out.output_scores)
-
-        return decoder_out._replace(
-            output_tokens=initial_output_tokens, output_scores=initial_output_scores
-        )
+        length_tgt = (length_tgt[:, None] + utils.new_arange(length_tgt, 1, beam_size) - beam_size // 2)
+        initial_output_tokens = self._get_initial_outputs(length_tgt, length_tgt)
+        initial_output_scores = initial_output_tokens.new_zeros(*initial_output_tokens.size()).type_as(decoder_out.output_scores)
+        return decoder_out._replace(output_tokens=initial_output_tokens, output_scores=initial_output_scores)
 
 
 class NATransformerDecoder(FairseqNATDecoder):
     def __init__(self, args, dictionary, embed_tokens, no_encoder_attn=False):
-        super().__init__(
-            args, dictionary, embed_tokens, no_encoder_attn=no_encoder_attn
-        )
+        super().__init__(args, dictionary, embed_tokens, no_encoder_attn=no_encoder_attn)
         self.dictionary = dictionary
         self.bos = dictionary.bos()
         self.unk = dictionary.unk()
         self.eos = dictionary.eos()
+        self.pad = dictionary.pad()
 
         self.encoder_embed_dim = args.encoder_embed_dim
         self.sg_length_pred = getattr(args, "sg_length_pred", False)
         self.pred_length_offset = getattr(args, "pred_length_offset", False)
         self.length_loss_factor = getattr(args, "length_loss_factor", 0.1)
         self.src_embedding_copy = getattr(args, "src_embedding_copy", False)
-        self.embed_length = Embedding(256, self.encoder_embed_dim, None)
+        self.no_decoder_input_embedding = getattr(args, "no_decoder_input_embedding", False)
+        self.use_ctc_decoder = getattr(args, 'use_ctc_decoder', False)
+
+        if not self.use_ctc_decoder:
+            self.embed_length = Embedding(getattr(args, "max_target_positions", 256), self.encoder_embed_dim, None)
+
+        if self.no_decoder_input_embedding:
+            delattr(self, "embed_tokens")
 
     @ensemble_decoder
-    def forward(self, normalize, encoder_out, prev_output_tokens, step=0, **unused):
-        features, _ = self.extract_features(
+    def forward(self, normalize, encoder_out, prev_output_tokens, step=0, return_deep_supervision=False, **unused):
+        features, extra = self.extract_features(
             prev_output_tokens,
             encoder_out=encoder_out,
             embedding_copy=(step == 0) & self.src_embedding_copy,
         )
-        decoder_out = self.output_layer(features)
-        return F.log_softmax(decoder_out, -1) if normalize else decoder_out
+        if return_deep_supervision:
+            deep_predictions = self.compute_deep_predictions(extra['inner_states'][1:], normalize) # skip the first element of extra since thats embedding
+        else:
+            decoder_out = self.output_layer(features)
+            if normalize:
+                decoder_out = F.log_softmax(decoder_out, -1)
+
+        return deep_predictions if return_deep_supervision else decoder_out
 
     @ensemble_decoder
     def forward_length(self, normalize, encoder_out):
@@ -243,6 +439,15 @@ class NATransformerDecoder(FairseqNATDecoder):
             enc_feats = enc_feats.detach()
         length_out = F.linear(enc_feats, self.embed_length.weight)
         return F.log_softmax(length_out, -1) if normalize else length_out
+
+    def get_length_target(self, encoder_out, src_tokens, tgt_tokens=None, normalize=False):
+        if self.use_ctc_decoder:
+            length_out = None
+            length_tgt = torch.sum(src_tokens.ne(self.pad), -1) * self.args.ctc_src_upsample_scale
+        else:
+            length_out = self.forward_length(normalize=normalize, encoder_out=encoder_out)
+            length_tgt = self.forward_length_prediction(length_out, encoder_out, tgt_tokens)
+        return length_tgt, length_out
 
     def extract_features(
         self,
@@ -338,14 +543,19 @@ class NATransformerDecoder(FairseqNATDecoder):
 
         # embed tokens and positions
         if states is None:
-            x = self.embed_scale * self.embed_tokens(prev_output_tokens)
-            if self.project_in_dim is not None:
-                x = self.project_in_dim(x)
+            if not self.no_decoder_input_embedding:
+                x = self.embed_scale * self.embed_tokens(prev_output_tokens)
+                if self.project_in_dim is not None:
+                    x = self.project_in_dim(x)
         else:
             x = states
 
         if positions is not None:
-            x += positions
+            if self.no_decoder_input_embedding and states is None:
+                x = positions
+            else:
+                x += positions
+
         x = self.dropout_module(x)
         decoder_padding_mask = prev_output_tokens.eq(self.padding_idx)
         return x, decoder_padding_mask
@@ -400,57 +610,42 @@ class NATransformerDecoder(FairseqNATDecoder):
 
         return length_tgt
 
+    def compute_deep_predictions(self, x, normalize):
+        if x:
+            if self.layer_norm:
+                x[-1] = self.layer_norm(x[-1])
+            x = torch.stack(x) # [decoder_layers, T, B, C]
+            x = x.transpose(1,2)
+            if self.project_out_dim is not None:
+                x = self.project_out_dim(x)
+            x = self.output_layer(x)
+            if normalize:
+                x = F.log_softmax(x, -1)
+            return x
 
-@register_model_architecture(
-    "nonautoregressive_transformer", "nonautoregressive_transformer"
-)
-def base_architecture(args):
-    args.encoder_embed_path = getattr(args, "encoder_embed_path", None)
-    args.encoder_embed_dim = getattr(args, "encoder_embed_dim", 512)
-    args.encoder_ffn_embed_dim = getattr(args, "encoder_ffn_embed_dim", 2048)
-    args.encoder_layers = getattr(args, "encoder_layers", 6)
-    args.encoder_attention_heads = getattr(args, "encoder_attention_heads", 8)
-    args.encoder_normalize_before = getattr(args, "encoder_normalize_before", False)
-    args.encoder_learned_pos = getattr(args, "encoder_learned_pos", False)
-    args.decoder_embed_path = getattr(args, "decoder_embed_path", None)
-    args.decoder_embed_dim = getattr(args, "decoder_embed_dim", args.encoder_embed_dim)
-    args.decoder_ffn_embed_dim = getattr(
-        args, "decoder_ffn_embed_dim", args.encoder_ffn_embed_dim
-    )
-    args.decoder_layers = getattr(args, "decoder_layers", 6)
-    args.decoder_attention_heads = getattr(args, "decoder_attention_heads", 8)
-    args.decoder_normalize_before = getattr(args, "decoder_normalize_before", False)
-    args.decoder_learned_pos = getattr(args, "decoder_learned_pos", False)
-    args.attention_dropout = getattr(args, "attention_dropout", 0.0)
-    args.activation_dropout = getattr(args, "activation_dropout", 0.0)
-    args.activation_fn = getattr(args, "activation_fn", "relu")
-    args.dropout = getattr(args, "dropout", 0.1)
-    args.adaptive_softmax_cutoff = getattr(args, "adaptive_softmax_cutoff", None)
-    args.adaptive_softmax_dropout = getattr(args, "adaptive_softmax_dropout", 0)
-    args.share_decoder_input_output_embed = getattr(
-        args, "share_decoder_input_output_embed", False
-    )
-    args.share_all_embeddings = getattr(args, "share_all_embeddings", False)
-    args.no_token_positional_embeddings = getattr(
-        args, "no_token_positional_embeddings", False
-    )
-    args.adaptive_input = getattr(args, "adaptive_input", False)
+@register_model_architecture("nonautoregressive_transformer", "nonautoregressive_transformer")
+def base_nonautoregressive_architecture(args):
+    base_architecture(args)
     args.apply_bert_init = getattr(args, "apply_bert_init", False)
-
-    args.decoder_output_dim = getattr(
-        args, "decoder_output_dim", args.decoder_embed_dim
-    )
-    args.decoder_input_dim = getattr(args, "decoder_input_dim", args.decoder_embed_dim)
 
     # --- special arguments ---
     args.sg_length_pred = getattr(args, "sg_length_pred", False)
     args.pred_length_offset = getattr(args, "pred_length_offset", False)
     args.length_loss_factor = getattr(args, "length_loss_factor", 0.1)
     args.src_embedding_copy = getattr(args, "src_embedding_copy", False)
+    args.no_decoder_input_embedding = getattr(args, "no_decoder_input_embedding", False)
 
+    # --- GLAT ---
+    args.use_glat = getattr(args, "use_glat", False)
+    args.use_glat_with_nat_aux = getattr(args, "use_glat_with_nat_aux", False)
+    args.glat_nat_aux_factor = getattr(args, "glat_nat_aux_factor", 1)
+    args.glat_nat_aux_layers = getattr(args, "glat_nat_aux_layers", args.decoder_layers)
 
-@register_model_architecture(
-    "nonautoregressive_transformer", "nonautoregressive_transformer_wmt_en_de"
-)
-def nonautoregressive_transformer_wmt_en_de(args):
-    base_architecture(args)
+    # --- CTC ---
+    args.use_ctc_decoder = getattr(args, "use_ctc_decoder", False)
+    args.ctc_src_upsample_scale = getattr(args, "ctc_src_upsample_scale", 2)
+    args.use_ctc_beam_decoder = getattr(args, "use_ctc_beam_decoder", False)
+    args.ctc_beam_size = getattr(args, "ctc_beam_size", 1)
+
+    # --- DSLP ---
+    args.use_deep_supervision = getattr(args, "use_deep_supervision", False)

--- a/fairseq/tasks/multilingual_translation.py
+++ b/fairseq/tasks/multilingual_translation.py
@@ -18,7 +18,7 @@ from fairseq.data import (
     TransformEosLangPairDataset,
 )
 from fairseq.models import FairseqMultiModel
-from fairseq.tasks.translation import load_langpair_dataset
+from fairseq.tasks.translation import load_langpair_dataset, valid_bleu
 
 from . import LegacyFairseqTask, register_task
 
@@ -380,6 +380,9 @@ class MultilingualTranslationTask(LegacyFairseqTask):
     def _per_lang_pair_valid_loss(self, lang_pair, model, criterion, sample):
         return criterion(model.models[lang_pair], sample[lang_pair])
 
+    def _per_lang_pair_valid_bleu(self, lang_pair, model, sample, logging_output):
+        valid_bleu(self, self.sequence_generator[lang_pair], sample[lang_pair], model.models[lang_pair], logging_output)
+
     def valid_step(self, sample, model, criterion):
         model.eval()
         with torch.no_grad():
@@ -396,6 +399,10 @@ class MultilingualTranslationTask(LegacyFairseqTask):
                 loss, sample_size, logging_output = self._per_lang_pair_valid_loss(
                     lang_pair, model, criterion, sample
                 )
+
+                if self.args.eval_bleu:
+                    self._per_lang_pair_valid_bleu(lang_pair, model, sample, logging_output)
+
                 agg_loss += loss.data.item()
                 # TODO make summing of the sample sizes configurable
                 agg_sample_size += sample_size

--- a/fairseq/tasks/translation.py
+++ b/fairseq/tasks/translation.py
@@ -169,6 +169,16 @@ def load_langpair_dataset(
         pad_to_multiple=pad_to_multiple,
     )
 
+def valid_bleu(self, sequence_generator, sample, model, logging_output):
+    bleu = TranslationTask._inference_with_bleu(self, sequence_generator, sample, model)
+    logging_output["_bleu_sys_len"] = bleu.sys_len
+    logging_output["_bleu_ref_len"] = bleu.ref_len
+    # we split counts into separate entries so that they can be
+    # summed efficiently across workers using fast-stat-sync
+    assert len(bleu.counts) == EVAL_BLEU_ORDER
+    for i in range(EVAL_BLEU_ORDER):
+        logging_output["_bleu_counts_" + str(i)] = bleu.counts[i]
+        logging_output["_bleu_totals_" + str(i)] = bleu.totals[i]
 
 @dataclass
 class TranslationConfig(FairseqDataclass):
@@ -210,7 +220,7 @@ class TranslationConfig(FairseqDataclass):
         default=1024, metadata={"help": "max number of tokens in the target sequence"}
     )
     upsample_primary: int = field(
-        default=-1, metadata={"help": "the amount of upsample primary dataset"}
+        default=1, metadata={"help": "the amount of upsample primary dataset"}
     )
     truncate_source: bool = field(
         default=False, metadata={"help": "truncate source to max-source-positions"}
@@ -382,15 +392,8 @@ class TranslationTask(FairseqTask):
     def valid_step(self, sample, model, criterion):
         loss, sample_size, logging_output = super().valid_step(sample, model, criterion)
         if self.cfg.eval_bleu:
-            bleu = self._inference_with_bleu(self.sequence_generator, sample, model)
-            logging_output["_bleu_sys_len"] = bleu.sys_len
-            logging_output["_bleu_ref_len"] = bleu.ref_len
-            # we split counts into separate entries so that they can be
-            # summed efficiently across workers using fast-stat-sync
-            assert len(bleu.counts) == EVAL_BLEU_ORDER
-            for i in range(EVAL_BLEU_ORDER):
-                logging_output["_bleu_counts_" + str(i)] = bleu.counts[i]
-                logging_output["_bleu_totals_" + str(i)] = bleu.totals[i]
+            valid_bleu(self, self.sequence_generator, sample, model, logging_output)
+            
         return loss, sample_size, logging_output
 
     def reduce_metrics(self, logging_outputs, criterion):


### PR DESCRIPTION
This PR adds the code for the following methods to the Non-Autoregressive Transformer:

- Glancing Transformer (GLAT) from "[Glancing Transformer for Non-Autoregressive Neural Machine Translation](https://aclanthology.org/2021.acl-long.155.pdf)" (Qian et al., 2021)
- Connectionist Temporal Classification (CTC) from "[End-to-End Non-Autoregressive Neural Machine Translation with Connectionist Temporal Classification](https://aclanthology.org/D18-1336.pdf)" (Libovický & Helcl, 2018)
- Deep Supervision (DS) from "[Non-Autoregressive Translation with Layer-Wise Prediction and Deep Supervision](https://arxiv.org/abs/2110.07515)" (Huang et al., 2021)

Important to note is that this code still has one more dependency on the C++ code from [torch_imputer](https://github.com/rosinality/imputer-pytorch) that is currently not integrated in this PR. We leave it up to the fairseq team to decide how they want to include the `best_alignment` method for `fairseq/models/nat/nonautoregressive_transformer.py` (l. 171). Both, building a pip package and importing it or directly copying over the code from the respective repository would work. It is used for getting Viterbi-aligned target tokens when using CTC + GLAT jointly.

Main flags for training using any of the above methods are:

- GLAT: `--use-glat`
- CTC: `--use-ctc-decoder --ctc-src-upsample-scale 2`
- DS: `--use-deep-supervision`

These are also supported jointly. Once this PR has been integrated, we'll work on getting a follow-up PR up for the required inference speed improvements i.e. Shortlists and Average Attention (see below paper). As these are not specific to non-autoregressive models, we decided to keep them separate.

If anyone using this code finds it helpful, please consider citing our [associated paper](https://arxiv.org/abs/2205.10577):

> **Abstract:** *Non-autoregressive approaches aim to improve the inference speed of translation models by only requiring a single forward pass to generate the output sequence instead of iteratively producing each predicted token. Consequently, their translation quality still tends to be inferior to their autoregressive counterparts due to several issues involving output token interdependence. In this work, we take a step back and revisit several techniques that have been proposed for improving non-autoregressive translation models and compare their combined translation quality and speed implications under third-party testing environments. We provide novel insights for establishing strong baselines using length prediction or CTC-based architecture variants and contribute standardized BLEU, chrF++, and TER scores using sacreBLEU on four translation tasks, which crucially have been missing as inconsistencies in the use of tokenized BLEU lead to deviations of up to 1.7 BLEU points. Our open-sourced code is integrated into fairseq for reproducibility.*

```bibtex
@misc{schmidt2022nat,
  url = {https://arxiv.org/abs/2205.10577}, 
  author = {Schmidt, Robin M. and Pires, Telmo and Peitz, Stephan and Lööf, Jonas},
  title = {Non-Autoregressive Neural Machine Translation: A Call for Clarity},
  publisher = {arXiv},
  year = {2022}
}
```