### PR TITLE
Add fix and back compat for changed private omegaconf api

### DIFF
--- a/fairseq/dataclass/utils.py
+++ b/fairseq/dataclass/utils.py
@@ -364,7 +364,7 @@ def override_module_args(args: Namespace) -> Tuple[List[str], List[str]]:
 
 class omegaconf_no_object_check:
     def __init__(self):
-        # Changed in https://github.com/omry/omegaconf/pull/911 - both are kept for back compat. 
+        # Changed in https://github.com/omry/omegaconf/pull/911 - both are kept for back compat.
         if hasattr(_utils, "is_primitive_type"):
             self.old_is_primitive = _utils.is_primitive_type
         else:

--- a/fairseq/dataclass/utils.py
+++ b/fairseq/dataclass/utils.py
@@ -371,10 +371,16 @@ class omegaconf_no_object_check:
             self.old_is_primitive = _utils.is_primitive_type_annotation
 
     def __enter__(self):
-        _utils.is_primitive_type_annotation = lambda _: True
+        if hasattr(_utils, "is_primitive_type"):
+            _utils.is_primitive_type = lambda _: True
+        else:
+            _utils.is_primitive_type_annotation = lambda _: True
 
     def __exit__(self, type, value, traceback):
-        _utils.is_primitive_type_annotation = self.old_is_primitive
+        if hasattr(_utils, "is_primitive_type"):
+            _utils.is_primitive_type = self.old_is_primitive
+        else:
+            _utils.is_primitive_type_annotation = self.old_is_primitive
 
 
 def convert_namespace_to_omegaconf(args: Namespace) -> DictConfig:

--- a/fairseq/dataclass/utils.py
+++ b/fairseq/dataclass/utils.py
@@ -371,10 +371,10 @@ class omegaconf_no_object_check:
             self.old_is_primitive = _utils.is_primitive_type_annotation
 
     def __enter__(self):
-        _utils.is_primitive_type = lambda _: True
+        _utils.is_primitive_type_annotation = lambda _: True
 
     def __exit__(self, type, value, traceback):
-        _utils.is_primitive_type = self.old_is_primitive
+        _utils.is_primitive_type_annotation = self.old_is_primitive
 
 
 def convert_namespace_to_omegaconf(args: Namespace) -> DictConfig:

--- a/fairseq/dataclass/utils.py
+++ b/fairseq/dataclass/utils.py
@@ -364,7 +364,11 @@ def override_module_args(args: Namespace) -> Tuple[List[str], List[str]]:
 
 class omegaconf_no_object_check:
     def __init__(self):
-        self.old_is_primitive = _utils.is_primitive_type
+        # Changed in https://github.com/omry/omegaconf/pull/911 - both are kept for back compat. 
+        if hasattr(_utils, "is_primitive_type"):
+            self.old_is_primitive = _utils.is_primitive_type
+        else:
+            self.old_is_primitive = _utils.is_primitive_type_annotation
 
     def __enter__(self):
         _utils.is_primitive_type = lambda _: True


### PR DESCRIPTION
Alternatively, we could pin a version of omegaconf

# Before submitting

- [X ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements) No
- [X ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)? Yes
- [X ] Did you make sure to update the docs? N/A
- [ X] Did you write any new necessary tests? N/A

## What does this PR do?
No issue opened, but noticed when running torchbenchmark

## PR review


## Did you have fun?
The most fun you can have with your clothes on

