### PR TITLE
hydra-te translation_from_pretrained_bart

### DIFF
--- a/fairseq/tasks/translation_from_pretrained_bart.py
+++ b/fairseq/tasks/translation_from_pretrained_bart.py
@@ -2,16 +2,42 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+from dataclasses import dataclass, field
 
 import torch
 from fairseq import utils
 from fairseq.data import LanguagePairDataset
+from fairseq.tasks import register_task
+from fairseq.tasks.translation import (TranslationConfig, TranslationTask,
+                                       load_langpair_dataset)
+from omegaconf import MISSING
 
-from . import register_task
-from .translation import TranslationTask, load_langpair_dataset
+
+@dataclass
+class TranslationFromPretrainedBARTConfig(TranslationConfig):
+    langs: str = field(
+        default=MISSING,
+        metadata={
+            "help": "comma-separated list of monolingual language, "
+            'for example, "en,de,fr". These should match the '
+            "langs from pretraining (and be in the same order). "
+            "You should always add all pretraining language idx "
+            "during finetuning."
+        },
+    )
+
+    preprend_bos: bool = field(
+        default=False,
+        metadata={
+            "help": "prepend bos token to each sentence, which matches "
+            "mBART pretraining"
+        },
+    )
 
 
-@register_task("translation_from_pretrained_bart")
+@register_task(
+    "translation_from_pretrained_bart", dataclass=TranslationFromPretrainedBARTConfig
+)
 class TranslationFromPretrainedBARTTask(TranslationTask):
     """
     Translate from source language to target language with a model initialized with a multilingual pretrain.
@@ -33,25 +59,9 @@ class TranslationFromPretrainedBARTTask(TranslationTask):
         :prog:
     """
 
-    @staticmethod
-    def add_args(parser):
-        """Add task-specific arguments to the parser."""
-        # fmt: off
-        TranslationTask.add_args(parser)
-        parser.add_argument('--langs',  type=str, metavar='LANG',
-                            help='comma-separated list of monolingual language, '
-                                 'for example, "en,de,fr". These should match the '
-                                 'langs from pretraining (and be in the same order). '
-                                 'You should always add all pretraining language idx '
-                                 'during finetuning.')
-        parser.add_argument('--prepend-bos', action='store_true',
-                            help='prepend bos token to each sentence, which matches '
-                                 'mBART pretraining')
-        # fmt: on
-
-    def __init__(self, args, src_dict, tgt_dict):
-        super().__init__(args, src_dict, tgt_dict)
-        self.langs = args.langs.split(",")
+    def __init__(self, cfg, src_dict, tgt_dict):
+        super().__init__(cfg, src_dict, tgt_dict)
+        self.langs = cfg.langs.split(",")
         for d in [src_dict, tgt_dict]:
             for l in self.langs:
                 d.add_symbol("[{}]".format(l))
@@ -63,12 +73,12 @@ class TranslationFromPretrainedBARTTask(TranslationTask):
         Args:
             split (str): name of the split (e.g., train, valid, test)
         """
-        paths = utils.split_paths(self.args.data)
+        paths = utils.split_paths(self.cfg.data)
         assert len(paths) > 0
         data_path = paths[(epoch - 1) % len(paths)]
 
         # infer langcode
-        src, tgt = self.args.source_lang, self.args.target_lang
+        src, tgt = self.cfg.source_lang, self.cfg.target_lang
 
         self.datasets[split] = load_langpair_dataset(
             data_path,
@@ -78,24 +88,24 @@ class TranslationFromPretrainedBARTTask(TranslationTask):
             tgt,
             self.tgt_dict,
             combine=combine,
-            dataset_impl=self.args.dataset_impl,
-            upsample_primary=self.args.upsample_primary,
-            left_pad_source=self.args.left_pad_source,
-            left_pad_target=self.args.left_pad_target,
-            max_source_positions=getattr(self.args, "max_source_positions", 1024),
-            max_target_positions=getattr(self.args, "max_target_positions", 1024),
-            load_alignments=self.args.load_alignments,
-            prepend_bos=getattr(self.args, "prepend_bos", False),
+            dataset_impl=self.cfg.dataset_impl,
+            upsample_primary=self.cfg.upsample_primary,
+            left_pad_source=self.cfg.left_pad_source,
+            left_pad_target=self.cfg.left_pad_target,
+            max_source_positions=getattr(self.cfg, "max_source_positions", 1024),
+            max_target_positions=getattr(self.cfg, "max_target_positions", 1024),
+            load_alignments=self.cfg.load_alignments,
+            prepend_bos=getattr(self.cfg, "prepend_bos", False),
             append_source_id=True,
         )
 
-    def build_generator(self, models, args, **unused):
-        if getattr(args, "score_reference", False):
+    def build_generator(self, models, cfg, **unused):
+        if getattr(cfg, "score_reference", False):
             from fairseq.sequence_scorer import SequenceScorer
 
             return SequenceScorer(
                 self.target_dictionary,
-                eos=self.tgt_dict.index("[{}]".format(self.args.target_lang)),
+                eos=self.tgt_dict.index("[{}]".format(self.cfg.target_lang)),
             )
         else:
             from fairseq.sequence_generator import SequenceGenerator
@@ -103,21 +113,22 @@ class TranslationFromPretrainedBARTTask(TranslationTask):
             return SequenceGenerator(
                 models,
                 self.target_dictionary,
-                beam_size=getattr(args, "beam", 5),
-                max_len_a=getattr(args, "max_len_a", 0),
-                max_len_b=getattr(args, "max_len_b", 200),
-                min_len=getattr(args, "min_len", 1),
-                normalize_scores=(not getattr(args, "unnormalized", False)),
-                len_penalty=getattr(args, "lenpen", 1),
-                unk_penalty=getattr(args, "unkpen", 0),
-                temperature=getattr(args, "temperature", 1.0),
-                match_source_len=getattr(args, "match_source_len", False),
-                no_repeat_ngram_size=getattr(args, "no_repeat_ngram_size", 0),
-                eos=self.tgt_dict.index("[{}]".format(self.args.target_lang)),
+                cfg.get("beam", 5),
+                cfg.get("max_len_a", 0),
+                cfg.get("max_len_b", 200),
+                cfg.get("max_len", 0),
+                cfg.get("min_len", 1),
+                not cfg.get("unnormalized", False),
+                cfg.get("lenpen", 1),
+                cfg.get("unkpen", 0),
+                cfg.get("temperature", 1.0),
+                cfg.get("match_source_len", False),
+                cfg.get("no_repeat_ngram_size", 0),
+                eos=self.tgt_dict.index("[{}]".format(self.cfg.target_lang)),
             )
 
     def build_dataset_for_inference(self, src_tokens, src_lengths, constraints=None):
-        src_lang_id = self.source_dictionary.index("[{}]".format(self.args.source_lang))
+        src_lang_id = self.source_dictionary.index("[{}]".format(self.cfg.source_lang))
         source_tokens = []
         for s_t in src_tokens:
             s_t = torch.cat([s_t, s_t.new(1).fill_(src_lang_id)])

--- a/fairseq/tasks/translation_from_pretrained_bart.py
+++ b/fairseq/tasks/translation_from_pretrained_bart.py
@@ -26,7 +26,7 @@ class TranslationFromPretrainedBARTConfig(TranslationConfig):
         },
     )
 
-    preprend_bos: bool = field(
+    prepend_bos: bool = field(
         default=False,
         metadata={
             "help": "prepend bos token to each sentence, which matches "


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? #3169 discusses an error relating to using `self.args` instead of `self.cfg`
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs? no api changes
- [x] Did you write any new necessary tests? no api changes

## What does this PR do?
Changes `translation_from_pretrained_bart` task to use hydra cfg
Changes imports from relative to absolute (`.translation` to `fairseq.tasks.translation`)
Updates call to `SequenceGenerator` to include new arg `max_len`
Fixes #3169 

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃

Note: Same changes in new PR that was closed by accident. See old PRs #4010 #4258