### PR TITLE
Fix CUDA runtime error sampleMultinomialOnce #2286

### DIFF
--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -375,6 +375,7 @@ class SequenceGenerator(nn.Module):
             if step >= max_len:
                 lprobs[:, : self.eos] = -math.inf
                 lprobs[:, self.eos + 1 :] = -math.inf
+                lprobs[:, self.eos] = 1
 
             # handle prefix tokens (possibly with different lengths)
             if (


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes #2286 by applying [the fix](https://github.com/facebookresearch/fairseq/issues/2286#issuecomment-891420884) suggested by @ryonakamura. 

**Causes of the issue**
PyTorch throws a CUDA assert error about `sampleMultinomialOnce` when we try to sample from a distribution that contains all zero (i.e. sum > accZero, see torch implementation [here](https://github.com/pytorch/pytorch/blob/master/aten/src/ATen/native/cuda/MultinomialKernel.cu#L226)). 
When we try to sample the next token after the max length, `fairseq` will set the log probability to all other tokens except `self.eos` to be `-inf` (see `fairseq` implementation [here](https://github.com/facebookresearch/fairseq/blob/a0ceabc287e26f64517fadb13a54c83b71e8e469/fairseq/sequence_generator.py#L362)).

The log probability for `self.eos` is unlikely to be `-inf` from the model, therefore the multinomial sampling should always sample EOS in this case. Yet in practice, when we take the exponent of the log-probability, the probability for EOS WILL be 0 in some cases potentially due to floating point precision (making the vector to contains all zero), and this causes the CUDA assert to be thrown.


[The fix](https://github.com/facebookresearch/fairseq/issues/2286#issuecomment-891420884) suggests by @ryonakamura manually set the log probability for EOS to be 1, hence `exp(1) = e > 0` which will no longer trigger the CUDA error, and will sample the EOS as expected.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
