### PR TITLE
Load AMP checkpoint to FP32; save gradient scaler state

### DIFF
--- a/fairseq/optim/fairseq_optimizer.py
+++ b/fairseq/optim/fairseq_optimizer.py
@@ -160,6 +160,10 @@ class FairseqOptimizer(object):
             return self.optimizer.supports_flat_params
         return False
 
+    @property
+    def name(self):
+        return self.__class__.__name__
+
     def average_params(self):
         pass
 

--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -402,7 +402,7 @@ class Trainer(object):
             + [
                 {
                     "criterion_name": self.get_criterion().__class__.__name__,
-                    "optimizer_name": self.optimizer.__class__.__name__,
+                    "optimizer_name": self.optimizer.name,
                     "lr_scheduler_state": self.lr_scheduler.state_dict(),
                     "num_updates": self.get_num_updates(),
                 }
@@ -594,8 +594,8 @@ class Trainer(object):
                 last_optim["criterion_name"] == self.get_criterion().__class__.__name__
             ), f"Criterion does not match; please reset the optimizer (--reset-optimizer). {last_optim['criterion_name']} vs {self.get_criterion().__class__.__name__}"
             assert (
-                last_optim["optimizer_name"] == self.optimizer.__class__.__name__
-            ), f"Optimizer does not match; please reset the optimizer (--reset-optimizer). {last_optim['optimizer_name']} vs {self.optimizer.__class__.__name__}"
+                last_optim["optimizer_name"] == self.optimizer.name
+            ), f"Optimizer does not match; please reset the optimizer (--reset-optimizer). {last_optim['optimizer_name']} vs {self.optimizer.name}"
 
             if not reset_lr_scheduler:
                 self.lr_scheduler.load_state_dict(last_optim["lr_scheduler_state"])


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
- Enables loading model checkpoint trained with AMP into FP32 and vice versa.
- Saves the state of AMP gradient scaler with checkpoint.

The first change makes it possible to stop training in AMP if loss explodes, continue training in FP32 and switch back to AMP if needed.
Second change is mostly to continue with same value of gradient scaling rather than start from amp-init-scale every time.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
