### PR TITLE
Hubert: fix a typo that costed me a month of work

### DIFF
--- a/examples/hubert/simple_kmeans/README.md
+++ b/examples/hubert/simple_kmeans/README.md
@@ -46,7 +46,7 @@ Features would also be saved at `${feat_dir}/${split}_${rank}_${nshard}.{npy,len
 ## K-means clustering
 To fit a k-means model with `${n_clusters}` clusters on 10% of the `${split}` data, run
 ```sh
-python learn_kmeans.py ${feat_dir} ${split} ${nshard} ${km_path} ${n_cluster} --percent 0.1
+python learn_kmeans.py ${feat_dir} ${split} ${nshard} ${km_path} ${n_clusters} --percent 0.1
 ```
 This saves the k-means model to `${km_path}`.
 


### PR DESCRIPTION

## What does this PR do?
This PR fixes a trivial typo in HuBERT preprocessing guideline.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Yes. We spent a month of debugging HuBERT training as the loss was quickly going to zero. The culprit was that we accidentally created the cluster .dict.txt file as EMPTY due to this typo (the filed changed in this PR)
As a result, fairseq-train would load an empty dictionary, and the k-means clusters would all be replaced with 3 (UNK).
This loosely fits within my definition of fun.