### PR TITLE
data2vec: robustify check for target_model module

### DIFF
--- a/examples/data2vec/models/data2vec_text.py
+++ b/examples/data2vec/models/data2vec_text.py
@@ -254,7 +254,7 @@ class Data2VecTextModel(FairseqEncoderModel):
 
             self.encoder.lm_head = None
 
-        if self.encoder.target_model is None:
+        if hasattr(self.encoder, "target_model") and self.encoder.target_model is None:
             for k in list(state_dict.keys()):
                 if k.startswith(prefix + "encoder.target_model."):
                     del state_dict[k]


### PR DESCRIPTION
Hi,

this PR adds an check if the `target_model` module really exists in the encoder of a data2vec model.

With newer pretrained data2vec models, this check is really important because it led to an error as reported in #4534.