### PR TITLE
[nllb] remove unused train cluster.data_dir, update fairscale INSTALL instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,6 +27,8 @@ pip install -e .
 ```bash
 git clone https://github.com/facebookresearch/fairscale.git
 cd fairscale
+# needed when loading MoE checkpoint w/num_experts < num_gpus
+git checkout origin/experts_lt_gpus_moe_reload_fix
 pip install -e .
 ```
 

--- a/examples/nllb/modeling/train/conf/cfg/cluster/example.yaml
+++ b/examples/nllb/modeling/train/conf/cfg/cluster/example.yaml
@@ -1,5 +1,4 @@
 cluster_name: example
-data_dir: /data/nllb/
 partition: ???
 memory_multiplier: 50
 timeout_min: 1000

--- a/examples/nllb/modeling/train/train_script.py
+++ b/examples/nllb/modeling/train/train_script.py
@@ -20,7 +20,6 @@ from stopes.core import StopesModule
 @dataclass
 class ClusterConfig:
     cluster_name: str = MISSING
-    data_dir: str = MISSING
     partition: str = MISSING
     memory_multiplier: int = 0
     timeout_min: int = 1000


### PR DESCRIPTION
## What does this PR do?
Removes unused cluster.data_dir and updates INSTALL.md for fairscale to use the branch needed for MoE checkpoint loading when num_experts < num_gpus