### PR TITLE
Support S2UT models in HF demo

### DIFF
--- a/fairseq/hub_utils.py
+++ b/fairseq/hub_utils.py
@@ -70,10 +70,18 @@ def from_pretrained(
     if "user_dir" in kwargs:
         utils.import_user_module(argparse.Namespace(user_dir=kwargs["user_dir"]))
 
-    models, args, task = checkpoint_utils.load_model_ensemble_and_task(
-        [os.path.join(model_path, cpt) for cpt in checkpoint_file.split(os.pathsep)],
-        arg_overrides=kwargs,
-    )
+    model_paths = [
+        os.path.join(model_path, cpt) for cpt in checkpoint_file.split(os.pathsep)
+    ]
+    if "is_vocoder" in kwargs:
+        args = {"data": kwargs["data"], "model_path": model_paths}
+        task = None
+        models = None
+    else:
+        models, args, task = checkpoint_utils.load_model_ensemble_and_task(
+            model_paths,
+            arg_overrides=kwargs,
+        )
 
     return {
         "args": args,

--- a/fairseq/models/speech_to_text/hub_interface.py
+++ b/fairseq/models/speech_to_text/hub_interface.py
@@ -95,7 +95,11 @@ class S2THubInterface(nn.Module):
         prefix = cls.get_prefix_token(task, _tgt_lang)
         pred_tokens = generator.generate([model], sample, prefix_tokens=prefix)
         pred = cls.detokenize(task, pred_tokens[0][0]["tokens"])
-
+        eos_token = task.data_cfg.config.get("eos_token", None)
+        if eos_token:
+            units = pred.split(' ')
+            assert units[-1] == eos_token
+            pred = ' '.join(units[:-1])
         if synthesize_speech:
             pfx = f"{_tgt_lang}_" if task.data_cfg.prepend_tgt_lang_tag else ""
             tts_model_id = task.data_cfg.hub.get(f"{pfx}tts_model_id", None)

--- a/fairseq/models/speech_to_text/xm_transformer.py
+++ b/fairseq/models/speech_to_text/xm_transformer.py
@@ -499,7 +499,7 @@ class XMTransformerModel(FairseqEncoderDecoderModel):
         model_name_or_path,
         checkpoint_file="model.pt",
         data_name_or_path=".",
-        config_yaml="config_test.yaml",
+        config_yaml="config.yaml",
         task="speech_to_text",
         **kwargs,
     ):

--- a/fairseq/models/speech_to_text/xm_transformer.py
+++ b/fairseq/models/speech_to_text/xm_transformer.py
@@ -487,6 +487,9 @@ class XMTransformerModel(FairseqEncoderDecoderModel):
             "xm_transformer-21_en-xls_r_2b",
             "xm_transformer-en_15-xls_r_2b",
             "xm_transformer-22_16-xls_r_2b",
+            "xm_transformer_s2ut_es_en_st_asr_test",
+            "xm_transformer_s2ut_800m-en-es-st_plus_asr",
+            "xm_transformer_s2ut_800m-es-en-st-asr-bt_h1_2022"
         ]
         return {i: f"{base_url}/{i}.tar.gz" for i in model_ids}
 
@@ -496,7 +499,8 @@ class XMTransformerModel(FairseqEncoderDecoderModel):
         model_name_or_path,
         checkpoint_file="model.pt",
         data_name_or_path=".",
-        config_yaml="config.yaml",
+        config_yaml="config_test.yaml",
+        task="speech_to_text",
         **kwargs,
     ):
         from fairseq import hub_utils
@@ -507,6 +511,7 @@ class XMTransformerModel(FairseqEncoderDecoderModel):
             data_name_or_path,
             archive_map=cls.hub_models(),
             config_yaml=config_yaml,
+            task=task,
             **kwargs,
         )
         return S2THubInterface(x["args"], x["task"], x["models"][0])

--- a/fairseq/models/text_to_speech/__init__.py
+++ b/fairseq/models/text_to_speech/__init__.py
@@ -6,3 +6,4 @@
 from .tacotron2 import *  # noqa
 from .tts_transformer import *  # noqa
 from .fastspeech2 import *  # noqa
+from .vocoder import *  # noqa

--- a/fairseq/models/text_to_speech/vocoder.py
+++ b/fairseq/models/text_to_speech/vocoder.py
@@ -21,6 +21,8 @@ from fairseq.data.audio.audio_utils import (
 from fairseq.data.audio.speech_to_text_dataset import S2TDataConfig
 from fairseq.models.text_to_speech.codehifigan import CodeGenerator as CodeHiFiGANModel
 from fairseq.models.text_to_speech.hifigan import Generator as HiFiGANModel
+from fairseq.models.text_to_speech.hub_interface import VocoderHubInterface
+from fairseq.models import BaseFairseqModel, register_model
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +85,7 @@ class GriffinLim(torch.nn.Module):
         x = torch.zeros(n, dtype=torch.float32)
         for i in range(n_frames):
             ofst = i * hop_length
-            x[ofst : min(n, ofst + n_fft)] += w_sq[: max(0, min(n_fft, n - ofst))]
+            x[ofst: min(n, ofst + n_fft)] += w_sq[: max(0, min(n_fft, n - ofst))]
         return x
 
     def inverse(self, magnitude: torch.Tensor, phase) -> torch.Tensor:
@@ -101,8 +103,8 @@ class GriffinLim(torch.nn.Module):
         approx_nonzero_indices = win_sum_sq > self.tiny
         x[:, :, approx_nonzero_indices] /= win_sum_sq[approx_nonzero_indices]
         x *= self.n_fft / self.hop_length
-        x = x[:, :, self.n_fft // 2 :]
-        x = x[:, :, : -self.n_fft // 2 :]
+        x = x[:, :, self.n_fft // 2:]
+        x = x[:, :, : -self.n_fft // 2:]
         return x
 
     def forward(self, specgram: torch.Tensor) -> torch.Tensor:
@@ -211,7 +213,8 @@ class HiFiGANVocoder(nn.Module):
         return cls(vocoder_cfg["checkpoint"], model_cfg, fp16=args.fp16)
 
 
-class CodeHiFiGANVocoder(nn.Module):
+@register_model("codehifiganvocoder")
+class CodeHiFiGANVocoder(BaseFairseqModel):
     def __init__(
         self, checkpoint_path: str, model_cfg: Dict[str, str], fp16: bool = False
     ) -> None:
@@ -246,6 +249,43 @@ class CodeHiFiGANVocoder(nn.Module):
         with open(vocoder_cfg["config"]) as f:
             model_cfg = json.load(f)
         return cls(vocoder_cfg["checkpoint"], model_cfg, fp16=args.fp16)
+
+    @classmethod
+    def hub_models(cls):
+        base_url = "http://dl.fbaipublicfiles.com/fairseq/vocoder"
+        model_ids = ["unit_hifigan_mhubert_vp_en_es_fr_it3_400k_layer11_km1000_lj_dur",
+                     "unit_hifigan_mhubert_vp_en_es_fr_it3_400k_layer11_km1000_es_css10_dur"]
+        return {i: f"{base_url}/{i}.tar.gz" for i in model_ids}
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_name_or_path,
+        checkpoint_file="model.pt",
+        data_name_or_path=".",
+        config="config.json",
+        fp16: bool = False,
+        **kwargs,
+    ):
+        from fairseq import hub_utils
+
+        x = hub_utils.from_pretrained(
+            model_name_or_path,
+            checkpoint_file,
+            data_name_or_path,
+            archive_map=cls.hub_models(),
+            config_yaml=config,
+            fp16=fp16,
+            is_vocoder=True,
+            **kwargs,
+        )
+
+        with open(f"{x['args']['data']}/{config}") as f:
+            vocoder_cfg = json.load(f)
+        assert len(x["args"]["model_path"]) == 1, "Too many vocoder models in the input"
+
+        vocoder = CodeHiFiGANVocoder(x["args"]["model_path"][0], vocoder_cfg)
+        return VocoderHubInterface(vocoder_cfg, vocoder)
 
 
 def get_vocoder(args, data_cfg: S2TDataConfig):


### PR DESCRIPTION
Update the existing S2T and TTS hub interfaces to support S2UT model plus vocoder in the HF demo. As next steps will test and update the HF pipeline. The detailed changes in this PR are
1. Update CodeHifiGAN vocoder to inherit BaseFairseqModel instead of nn.Module to use the underlying hub interface. Also add relevant methods to the vocoder to load and infer using the models from S3 
2. Add VocoderHubInterface class to TTS hub interface to support waveform generation using CodeHifiGAN vocoders.
3. Add S2UT models to xm_transformer and update S2T interface accordingly
4. Tested the changes in a script in my local using the script located at 
/private/home/spopuri/speech_translation/fairseq_speech/test_HF_demo.py. Couldn't use google collab for testing due to GPU memory constraints