### PR TITLE
Fix tlayer torch JIT export

### DIFF
--- a/fairseq/modules/transformer_layer.py
+++ b/fairseq/modules/transformer_layer.py
@@ -563,7 +563,6 @@ class TransformerDecoderLayerBase(nn.Module):
         """
         if need_head_weights:
             need_attn = True
-
         residual = x
         if self.normalize_before:
             x = self.self_attn_layer_norm(x)
@@ -638,6 +637,11 @@ class TransformerDecoderLayerBase(nn.Module):
                 assert incremental_state is not None
                 self.encoder_attn._set_input_buffer(incremental_state, saved_state)
 
+            need_weights = need_attn
+            # To prevent "Could not cast value of type NoneType to bool" when torchscript export:
+            if self.need_attn is not None and self.training is not None:
+                need_weights = need_attn or (not self.training and self.need_attn)
+
             x, attn = self.encoder_attn(
                 query=x,
                 key=encoder_out,
@@ -645,7 +649,7 @@ class TransformerDecoderLayerBase(nn.Module):
                 key_padding_mask=encoder_padding_mask,
                 incremental_state=incremental_state,
                 static_kv=True,
-                need_weights=need_attn or (not self.training and self.need_attn),
+                need_weights=need_weights,
                 need_head_weights=need_head_weights,
             )
             x = self.dropout_module(x)


### PR DESCRIPTION
Fix tlayer torch JIT export exception:
"Could not cast value of type NoneType to bool"
When torch jit exporting, self.need_attn is None.
Fix #4459

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements): Issue created 1 month ago, no comment.
- [X] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests? I will if anyone comments/considers it necessary

## What does this PR do?
Fixes #4459.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
I ve created the Github issue 1 month ago, no comment as today: #4459

## Did you have fun?
not yet