### PR TITLE
Support direct S2ST models in HF demo

### DIFF
--- a/examples/speech_to_speech/docs/enhanced_direct_s2st_discrete_units.md
+++ b/examples/speech_to_speech/docs/enhanced_direct_s2st_discrete_units.md
@@ -38,7 +38,7 @@ sed -i "1s/.*/$var/" ${SPLIT}.tsv
 
 **Speech-to-unit translation (S2UT)**
 
-Here's an example for finetuning S2UT models with 1000 discrete units as target. You can download the [config](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/config.yaml) file and [vocabulary](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/dict.txt) from here:
+Here's an example for finetuning S2UT models with 1000 discrete units as target. You can download the sample [config](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/config.yaml) file and [vocabulary](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/dict.txt) for Es-En from here:
 
 ```
 fairseq-train $DATA_ROOT \
@@ -106,3 +106,20 @@ To evaluate speech translation output, we first apply ASR on the speech output a
 * En ASR: We use the "[Wav2Vec 2.0 Large (LV-60) + Self Training / 960 hours / Libri-Light + Librispeech](https://dl.fbaipublicfiles.com/fairseq/wav2vec/wav2vec_vox_960h_pl.pt)" En ASR model open-sourced by the [wav2vec](https://github.com/pytorch/fairseq/tree/main/examples/wav2vec) project. The model is also available on [Hugging Face](https://huggingface.co/facebook/wav2vec2-large-960h-lv60-self).
 * Es ASR: We use the [Wav2Vec2-Large-XLSR-53-Spanish](https://huggingface.co/facebook/wav2vec2-large-xlsr-53) finetuned on spanish Common Voice Es ASR model open-sourced by Jonatasgrosman(<https://huggingface.co/jonatasgrosman/wav2vec2-large-xlsr-53-spanish>) on [Hugging Face](https://huggingface.co/jonatasgrosman/wav2vec2-large-xlsr-53-spanish).
 * See [instructions](https://github.com/pytorch/fairseq/tree/main/examples/wav2vec#evaluating-a-ctc-model) on how to run inference with a wav2vec-based ASR model.
+
+
+## Finetuned Model Checkpoints
+
+ID | En - Es | Es - En |
+| --- | --- | --- |
+**S2UT systems without pre-training**
+S2UT with multitask | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/en_es//S2UT_w_multitask.pt) | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/es_en//S2UT_w_multitask.pt) | 
+**S2UT systems with model pre-training**
+w2v2-L | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/en_es//w2v2_only.pt ) | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/es_en//w2v2_only.pt) | 
+w2v2-L + mBART (LNA-E) | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/en_es//w2v2_mbart_LNE.pt) | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/es_en//w2v2_mbart_LNE.pt) | 
+w2v2-L + mBART (LNA-D) | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/en_es//w2v2_mbart_LND.pt) | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/es_en//w2v2_mbart_LND.pt) | 
+w2v2-L + mBART (LNA-E,D) | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/en_es//w2v2_mbart_LNED.pt) | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/es_en//w2v2_mbart_LNED.pt) | 
+**S2UT systems with model pre-training and data augmentation**
+w2v2-L + mBART (LNA-D) | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/en_es//w2v2_mbart_LND_w_ASR.pt) | [checkpoint](https://dl.fbaipublicfiles.com/fairseq/speech_to_speech/s2st_finetuning/es_en//w2v2_mbart_LND_w_ASR.pt) |
+
+Note: Some of the tasks use speech_to_text_sharded task which is yet to be open sourced. So make sure to override the task to speech_to_text to use those models.

--- a/fairseq/hub_utils.py
+++ b/fairseq/hub_utils.py
@@ -70,10 +70,19 @@ def from_pretrained(
     if "user_dir" in kwargs:
         utils.import_user_module(argparse.Namespace(user_dir=kwargs["user_dir"]))
 
-    models, args, task = checkpoint_utils.load_model_ensemble_and_task(
-        [os.path.join(model_path, cpt) for cpt in checkpoint_file.split(os.pathsep)],
-        arg_overrides=kwargs,
-    )
+    model_path = [
+        os.path.join(model_path, cpt) for cpt in checkpoint_file.split(os.pathsep)
+    ]
+
+    if "is_vocoder" in kwargs:
+        args = {"data": kwargs["data"], "model_path": model_path}
+        task = None
+        models = None
+    else:
+        models, args, task = checkpoint_utils.load_model_ensemble_and_task(
+            model_path,
+            arg_overrides=kwargs,
+        )
 
     return {
         "args": args,

--- a/fairseq/models/speech_to_text/hub_interface.py
+++ b/fairseq/models/speech_to_text/hub_interface.py
@@ -105,8 +105,11 @@ class S2THubInterface(nn.Module):
             if tts_model_id is None:
                 logger.warning("TTS model configuration not found")
             else:
+                print(_repo)
+                import pdb
+                pdb.set_trace()
                 _repo, _id = tts_model_id.split(":")
-                _repo = "sravyaopuri388/fairseq"
+                _repo = "sravyapopuri388/fairseq"
                 tts_model = torch.hub.load(_repo, _id, verbose=False)
                 pred = (pred, tts_model.predict(pred))
         return pred

--- a/fairseq/models/speech_to_text/hub_interface.py
+++ b/fairseq/models/speech_to_text/hub_interface.py
@@ -105,11 +105,7 @@ class S2THubInterface(nn.Module):
             if tts_model_id is None:
                 logger.warning("TTS model configuration not found")
             else:
-                print(_repo)
-                import pdb
-                pdb.set_trace()
                 _repo, _id = tts_model_id.split(":")
-                _repo = "sravyapopuri388/fairseq"
                 tts_model = torch.hub.load(_repo, _id, verbose=False)
                 pred = (pred, tts_model.predict(pred))
         return pred

--- a/fairseq/models/speech_to_text/hub_interface.py
+++ b/fairseq/models/speech_to_text/hub_interface.py
@@ -95,6 +95,9 @@ class S2THubInterface(nn.Module):
         prefix = cls.get_prefix_token(task, _tgt_lang)
         pred_tokens = generator.generate([model], sample, prefix_tokens=prefix)
         pred = cls.detokenize(task, pred_tokens[0][0]["tokens"])
+        eos_token = task.data_cfg.config.get("eos_token", None)
+        if eos_token:
+            pred = ' '.join(pred.split(' ')[:-1])
 
         if synthesize_speech:
             pfx = f"{_tgt_lang}_" if task.data_cfg.prepend_tgt_lang_tag else ""
@@ -103,6 +106,7 @@ class S2THubInterface(nn.Module):
                 logger.warning("TTS model configuration not found")
             else:
                 _repo, _id = tts_model_id.split(":")
+                _repo = "sravyaopuri388/fairseq"
                 tts_model = torch.hub.load(_repo, _id, verbose=False)
                 pred = (pred, tts_model.predict(pred))
         return pred

--- a/fairseq/models/speech_to_text/xm_transformer.py
+++ b/fairseq/models/speech_to_text/xm_transformer.py
@@ -500,6 +500,7 @@ class XMTransformerModel(FairseqEncoderDecoderModel):
         checkpoint_file="model.pt",
         data_name_or_path=".",
         config_yaml="config.yaml",
+        task="speech_to_text",
         **kwargs,
     ):
         from fairseq import hub_utils
@@ -510,6 +511,7 @@ class XMTransformerModel(FairseqEncoderDecoderModel):
             data_name_or_path,
             archive_map=cls.hub_models(),
             config_yaml=config_yaml,
+            task=task,
             **kwargs,
         )
         return S2THubInterface(x["args"], x["task"], x["models"][0])

--- a/fairseq/models/speech_to_text/xm_transformer.py
+++ b/fairseq/models/speech_to_text/xm_transformer.py
@@ -487,6 +487,9 @@ class XMTransformerModel(FairseqEncoderDecoderModel):
             "xm_transformer-21_en-xls_r_2b",
             "xm_transformer-en_15-xls_r_2b",
             "xm_transformer-22_16-xls_r_2b",
+            "xm_transformer_s2ut_800m-es-en-st-asr-bt_h1_2022",
+            "xm_transformer_s2ut_800m-en-es-st_plus_asr",
+            "xm_transformer_s2ut_es_en_st_asr_test"
         ]
         return {i: f"{base_url}/{i}.tar.gz" for i in model_ids}
 

--- a/fairseq/models/text_to_speech/__init__.py
+++ b/fairseq/models/text_to_speech/__init__.py
@@ -6,3 +6,4 @@
 from .tacotron2 import *  # noqa
 from .tts_transformer import *  # noqa
 from .fastspeech2 import *  # noqa
+from .vocoder import *  # noqa

--- a/fairseq/models/text_to_speech/hub_interface.py
+++ b/fairseq/models/text_to_speech/hub_interface.py
@@ -137,3 +137,49 @@ class TTSHubInterface(nn.Module):
     ) -> Tuple[torch.Tensor, int]:
         sample = self.get_model_input(self.task, text, speaker, verbose=verbose)
         return self.get_prediction(self.task, self.model, self.generator, sample)
+
+
+class VocoderHubInterface(nn.Module):
+    def __init__(self, cfg, model):
+        super().__init__()
+        self.vocoder = model
+        self.vocoder.eval()
+        self.sr = 16000
+        self.multispkr = self.vocoder.model.multispkr
+        if self.multispkr:
+            logger.info("multi-speaker vocoder")
+            self.num_speakers = cfg.get(
+                "num_speakers",
+                200,
+            )  # following the default in codehifigan to set to 200
+
+    def get_model_inout(
+        self,
+        text: str,
+        speaker: Optional[int] = None,
+    ):
+        units = list(map(int, text.strip().split()))
+        x = {
+            "code": torch.LongTensor(units).view(1, -1),
+        }
+
+        if self.multispkr:
+            assert (
+                speaker < self.num_speakers
+            ), f"invalid --speaker-id ({speaker}) with total #speakers = {self.num_speakers}"
+            spk = random.randint(0, self.num_speakers - 1) if speaker == -1 else speaker
+            x["spkr"] = torch.LongTensor([spk]).view(1, 1)
+        return x
+
+    def get_prediction(self, sample, dur_prediction: Optional[bool] = True):
+        wav = self.vocoder(sample, dur_prediction)
+        return wav, self.sr
+
+    def predict(
+        self,
+        text: str,
+        speaker: Optional[int] = None,
+        dur_prediction: Optional[bool] = True,
+    ):
+        sample = self.get_model_inout(text, speaker)
+        return self.get_prediction(sample, dur_prediction)

--- a/fairseq/models/text_to_speech/hub_interface.py
+++ b/fairseq/models/text_to_speech/hub_interface.py
@@ -140,6 +140,7 @@ class TTSHubInterface(nn.Module):
 
 
 class VocoderHubInterface(nn.Module):
+    """Vocoder interface to run vocoder models through hub. Currently we only support unit vocoder"""
     def __init__(self, cfg, model):
         super().__init__()
         self.vocoder = model
@@ -156,7 +157,7 @@ class VocoderHubInterface(nn.Module):
     def get_model_inout(
         self,
         text: str,
-        speaker: Optional[int] = None,
+        speaker: Optional[int] = -1,
     ):
         units = list(map(int, text.strip().split()))
         x = {


### PR DESCRIPTION
Update the existing S2T and TTS hub interfaces to support S2UT model plus vocoder in the HF demo. As next steps will test and update the HF pipeline. The detailed changes in this PR are

1. Update CodeHifiGAN vocoder to inherit BaseFairseqModel instead of nn.Module to use the underlying hub interface. Also add relevant methods to the vocoder to load and infer using the models from S3
2. Add VocoderHubInterface class to TTS hub interface to support waveform generation using CodeHifiGAN vocoders.
3. Add S2UT models to xm_transformer and update S2T interface accordingly
4. Tested the changes in a script in my local using the script located at
/private/home/spopuri/speech_translation/fairseq_speech/test_HF_demo.py. Couldn't use google collab for testing due to GPU memory constraints