### PR TITLE
Merge source and target embedding tables into one table

### DIFF
--- a/fairseq/models/transformer/transformer_base.py
+++ b/fairseq/models/transformer/transformer_base.py
@@ -9,6 +9,8 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
+import logging
+
 from fairseq import utils
 from fairseq.dataclass.utils import gen_parser_from_dataclass
 from fairseq.distributed import fsdp_wrap
@@ -18,6 +20,9 @@ from fairseq.models.transformer import (
     TransformerDecoderBase,
     TransformerEncoderBase,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class TransformerModelBase(FairseqEncoderDecoderModel):
@@ -82,6 +87,18 @@ class TransformerModelBase(FairseqEncoderDecoderModel):
                 )
             encoder_embed_tokens = cls.build_embedding(
                 cfg, src_dict, cfg.encoder.embed_dim, cfg.encoder.embed_path
+            )
+            decoder_embed_tokens = encoder_embed_tokens
+            cfg.share_decoder_input_output_embed = True
+        elif cfg.merge_src_tgt_embed:
+            logger.info(f"source dict size: {len(src_dict)}")
+            logger.info(f"target dict size: {len(tgt_dict)}")
+            src_dict.update(tgt_dict)
+            task.src_dict = src_dict
+            task.tgt_dict = src_dict
+            logger.info(f"merged dict size: {len(src_dict)}")
+            encoder_embed_tokens = cls.build_embedding(
+                cfg, src_dict, cfg.encoder.embed_dim
             )
             decoder_embed_tokens = encoder_embed_tokens
             cfg.share_decoder_input_output_embed = True

--- a/fairseq/models/transformer/transformer_config.py
+++ b/fairseq/models/transformer/transformer_config.py
@@ -132,6 +132,14 @@ class TransformerConfig(FairseqDataclass):
             "help": "share encoder, decoder and output embeddings (requires shared dictionary and embed dim)"
         },
     )
+    merge_src_tgt_embed: bool = field(
+        default=False,
+        metadata={
+            "help": "if true then the source and target embedding table is "
+            "merged into one table. This is going to make the model smaller but "
+            "it might hurt performance."
+        }
+    )
     no_token_positional_embeddings: bool = field(
         default=False,
         metadata={

--- a/fairseq/models/transformer/transformer_legacy.py
+++ b/fairseq/models/transformer/transformer_legacy.py
@@ -174,6 +174,7 @@ def base_architecture(args):
     args.encoder_attention_heads = getattr(args, "encoder_attention_heads", 8)
     args.encoder_normalize_before = getattr(args, "encoder_normalize_before", False)
     args.encoder_learned_pos = getattr(args, "encoder_learned_pos", False)
+
     args.decoder_embed_path = getattr(args, "decoder_embed_path", None)
     args.decoder_embed_dim = getattr(args, "decoder_embed_dim", args.encoder_embed_dim)
     args.decoder_ffn_embed_dim = getattr(
@@ -193,6 +194,7 @@ def base_architecture(args):
         args, "share_decoder_input_output_embed", False
     )
     args.share_all_embeddings = getattr(args, "share_all_embeddings", False)
+    args.merge_src_tgt_embed = getattr(args, "merge_src_tgt_embed", False)
     args.no_token_positional_embeddings = getattr(
         args, "no_token_positional_embeddings", False
     )


### PR DESCRIPTION
Add support for merging source and target embedding table into one table. This feature might hurt performance, but it will decrease the size of the final model.
