### PR TITLE
padding fix in the adaptor layer

### DIFF
--- a/fairseq/models/speech_to_text/xm_transformer.py
+++ b/fairseq/models/speech_to_text/xm_transformer.py
@@ -86,6 +86,9 @@ class Conv1dAdaptor(nn.Module):
             x = x + 0.5 * self.proj(x)
             x = self.proj_ln(x)
 
+        if padding_mask is not None:
+            x = utils.index_put(x, padding_mask.T, 0)
+
         # T x B x C -> B x C x T
         x = x.transpose(0, 1).transpose(1, 2)
         out_lens = None
@@ -108,6 +111,7 @@ class Conv1dAdaptor(nn.Module):
         out_padding_mask = None
         if padding_mask is not None:
             out_padding_mask = lengths_to_padding_mask(out_lens.long())
+            x = utils.index_put(x, out_padding_mask.T, 0)
         return x, out_padding_mask
 
 
@@ -489,7 +493,7 @@ class XMTransformerModel(FairseqEncoderDecoderModel):
             "xm_transformer-22_16-xls_r_2b",
             "xm_transformer_s2ut_800m-es-en-st-asr-bt_h1_2022",
             "xm_transformer_s2ut_800m-en-es-st_plus_asr",
-            "xm_transformer_s2ut_es_en_st_asr_test"
+            "xm_transformer_s2ut_es_en_st_asr_test",
         ]
         return {i: f"{base_url}/{i}.tar.gz" for i in model_ids}
 


### PR DESCRIPTION
The input to adaptor layer was not padded properly so that resulting downsampled representation contained noise influenced by different batch sizes (i.e., depending on the batch max length). This fix ensures proper zeroing of padding positions of the encoder output before and after applying the convolutional downsamplings. 

The latter zeroing operation is a bit redundant, but it ensures that in potential extra processing the padded information won't influence results.

We verified internally that this fix alleviates the issue of score inconsistency w.r.t. to different values of batch size.