### PR TITLE
Update prepare_audio_v2.sh

### DIFF
--- a/examples/wav2vec/unsupervised/scripts/prepare_audio_v2.sh
+++ b/examples/wav2vec/unsupervised/scripts/prepare_audio_v2.sh
@@ -63,6 +63,7 @@ mkdir -p $tgt_dir/mfcc
 # Consider spliting corpus into chuncks for large corpus, see HuBERT preprocessing for more details
 python $FAIRSEQ_ROOT/examples/hubert/simple_kmeans/dump_mfcc_feature.py \
   $tgt_dir $train_split 1 0 $tgt_dir/mfcc
+python $FAIRSEQ_ROOT/examples/hubert/simple_kmeans/learn_kmeans.py ${tgt_dir}/mfcc ${train_split} 1 ${tgt_dir}/mfcc/cls${dim} ${dim}
 python $FAIRSEQ_ROOT/examples/hubert/simple_kmeans/dump_km_label.py \
   $tgt_dir/mfcc $train_split $tgt_dir/mfcc/cls$dim 1 0 $tgt_dir/mfcc/cls${dim}_idx
 cp $tgt_dir/mfcc/cls${dim}_idx/${train_split}_0_1.km $tgt_dir/$train_split.km


### PR DESCRIPTION
Fix a bug that dumping the km labels without actually learning the kmeans.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fixes # (4615).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
