### PR TITLE
fix wandb lagging at end of ddp training

### DIFF
--- a/fairseq/logging/progress_bar.py
+++ b/fairseq/logging/progress_bar.py
@@ -481,14 +481,6 @@ except ImportError:
     wandb = None
 
 
-def _wandb_finish():
-    if wandb is not None:
-        wandb.finish()
-
-
-atexit.register(_wandb_finish)
-
-
 class WandBProgressBarWrapper(BaseProgressBar):
     """Log to Weights & Biases."""
 

--- a/fairseq/logging/progress_bar.py
+++ b/fairseq/logging/progress_bar.py
@@ -481,6 +481,14 @@ except ImportError:
     wandb = None
 
 
+def _wandb_finish():
+    if wandb is not None:
+        wandb.finish()
+
+
+atexit.register(_wandb_finish)
+
+
 class WandBProgressBarWrapper(BaseProgressBar):
     """Log to Weights & Biases."""
 

--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -204,6 +204,13 @@ def main(cfg: FairseqConfig) -> None:
     train_meter.stop()
     logger.info("done training in {:.1f} seconds".format(train_meter.sum))
 
+    try:
+        import wandb
+
+        wandb.finish()
+    except ImportError:
+        pass
+
     # ioPath implementation to wait for all asynchronous file writes to complete.
     if cfg.checkpoint.write_checkpoints_asynchronously:
         logger.info(


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs? n/a
- [x] Did you write any new necessary tests? n/a

## What does this PR do?
Fixes #4619 in a not great way

We need to call `wandb.finish()` at the end of our code to let `wandb` know that the multiprocessing job is over. But this is non-trivial with the current setup of `progress_bar.py`. I tried adding `wandb.finish()` similar to how tensorboard writers are closed using `atexit` (see [here](https://github.com/facebookresearch/fairseq/blob/main/fairseq/logging/progress_bar.py#L420) ) but it doesn't work. 

The current solution adds it in `fairseq_cli.train` but if there is a more elegant solution that uses `progress_bar.py` I would be happy to change
