### PR TITLE
Added + to connect error message

### DIFF
--- a/fairseq/models/__init__.py
+++ b/fairseq/models/__init__.py
@@ -98,7 +98,7 @@ def build_model(cfg: FairseqDataclass, task, from_checkpoint=False):
                 ARCH_CONFIG_REGISTRY[model_type](cfg)
 
     assert model is not None, (
-        f"Could not infer model type from {cfg}. "
+        f"Could not infer model type from {cfg}. " +
         "Available models: {}".format(MODEL_DATACLASS_REGISTRY.keys())
         + f" Requested model type: {model_type}"
     )


### PR DESCRIPTION
# Before submitting

- [Typo] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [Yes] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [No] Did you make sure to update the docs?
- [No] Did you write any new necessary tests?

## What does this PR do?
Fixes the error message for when a custom model is not recognized by the model registry. Previously, only the first string was printed, f"Could not infer model type from {cfg}.", and not the later strings which are useful for debugging. Adding the connector + allows all three strings to be printed together following a failed assertion.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
