### PR TITLE
add an option to fetch datapoints within a batch in an async manner, …

### DIFF
--- a/fairseq/data/multi_corpus_dataset.py
+++ b/fairseq/data/multi_corpus_dataset.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import asyncio
 import logging
 import time
 from collections import OrderedDict
@@ -161,15 +162,42 @@ class MultiCorpusDataset(FairseqDataset):
         """
         return self.total_num_instances
 
-    def __getitem__(self, index):
+    async def getitem(self, index):
         new_index, key = self._map_index(index)
         try:
-            item = self.datasets[key][new_index]
+            if hasattr(self.datasets[key], "getitem"):
+                item = await self.datasets[key].getitem(new_index)
+            else:
+                item = self.datasets[key][new_index]
             item["full_id"] = index
             return item
         except Exception as e:
             e.args = (f"Error from {key} dataset", *e.args)
             raise
+
+    def __getitem__(self, index):
+        return asyncio.run(self.getitem(index))
+
+    async def getitems(self, indices):
+        # initialize a bunch of everstore read operations
+        # wait in the end to reduce overhead
+        # very helpful if io is latency bounded
+
+        max_concurrency = 32
+        sem = asyncio.Semaphore(max_concurrency)
+
+        async def controlled_getitem(index):
+            async with sem:
+                return await self.getitem(index)
+
+        coroutines = []
+        for index in indices:
+            coroutines.append(controlled_getitem(index))
+        results = await asyncio.gather(*coroutines)
+        return results
+
+    def __getitems__(self, indices):
+        return asyncio.run(self.getitems(indices))
 
     def collater(self, samples):
         """
@@ -254,3 +282,4 @@ class MultiCorpusDataset(FairseqDataset):
             with data_utils.numpy_seed(self.seed, self.epoch, self.distributed_rank):
                 np.random.shuffle(batches)
         return batches
+

--- a/fairseq/data/multi_corpus_dataset.py
+++ b/fairseq/data/multi_corpus_dataset.py
@@ -10,6 +10,7 @@ from collections import OrderedDict
 from typing import Dict, List, Optional
 
 import numpy as np
+
 from fairseq.data import data_utils
 
 from . import FairseqDataset
@@ -282,4 +283,3 @@ class MultiCorpusDataset(FairseqDataset):
             with data_utils.numpy_seed(self.seed, self.epoch, self.distributed_rank):
                 np.random.shuffle(batches)
         return batches
-


### PR DESCRIPTION
…which is helpful if the fetching is io bound

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
MultiCorpusDataset is a wrapper around a bunch of underlying datasets that provide map style access. Currently the __getitem__ function is an io blocking function that wait for the results to return before proceeding. This is okay if the dataset is in memory, however if the dataset is across network, this blocking function call would become a bottleneck.

To resolve this issue discussed above, some dataset implementation has provided a async version of the __getitem__, however MultiCorpusDataset does not currently support async function call, which makes them incompatable. This PR fixes this issue.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
