### PR TITLE
Add Conv2dSubsampler

### DIFF
--- a/fairseq/models/speech_to_speech/s2s_transformer.py
+++ b/fairseq/models/speech_to_speech/s2s_transformer.py
@@ -247,13 +247,19 @@ class S2UTTransformerModel(S2STransformerMultitaskModelBase):
             "--conv-kernel-sizes",
             type=str,
             metavar="N",
-            help="kernel sizes of Conv1d subsampling layers",
+            help="kernel sizes of Conv1d (s2t_transformer) subsampling layers",
         )
         parser.add_argument(
             "--conv-channels",
             type=int,
             metavar="N",
-            help="# of channels in Conv1d subsampling layers",
+            help="# of channels in Conv1d (s2t_transformer) subsampling layers",
+        )
+        parser.add_argument(
+            "--conv-out-channels",
+            type=int,
+            metavar="N",
+            help="# of channels in Conv2d (convtransformer) subsampling layers",
         )
         parser.add_argument(
             "--conv-version",
@@ -429,13 +435,13 @@ class S2SpecTTransformerModel(S2STransformerMultitaskModelBase):
             "--conv-kernel-sizes",
             type=str,
             metavar="N",
-            help="kernel sizes of Conv1d subsampling layers",
+            help="kernel sizes of Conv1d (s2t_transformer) subsampling layers",
         )
         parser.add_argument(
             "--conv-channels",
             type=int,
             metavar="N",
-            help="# of channels in Conv1d subsampling layers",
+            help="# of channels in Conv1d (s2t_transformer) subsampling layers",
         )
         parser.add_argument(
             "--conv-version",
@@ -614,8 +620,9 @@ def base_s2st_transformer_encoder_architecture(args):
 
     # Convolutional subsampler
     args.input_channels = getattr(args, "input_channels", 1)
-    args.conv_kernel_sizes = getattr(args, "conv_kernel_sizes", "5,5")
-    args.conv_channels = getattr(args, "conv_channels", 1024)
+    args.conv_kernel_sizes = getattr(args, "conv_kernel_sizes", "5,5")  # for Conv1d
+    args.conv_channels = getattr(args, "conv_channels", 1024)  # for Conv1d
+    args.conv_out_channels = getattr(args, "conv_out_channels", 256)  # for Conv2d
     args.conv_version = getattr(args, "conv_version", "s2t_transformer")
     # Transformer
     args.encoder_embed_dim = getattr(args, "encoder_embed_dim", 512)

--- a/fairseq/models/speech_to_speech/s2s_transformer.py
+++ b/fairseq/models/speech_to_speech/s2s_transformer.py
@@ -255,6 +255,13 @@ class S2UTTransformerModel(S2STransformerMultitaskModelBase):
             metavar="N",
             help="# of channels in Conv1d subsampling layers",
         )
+        parser.add_argument(
+            "--conv-version",
+            type=str,
+            default="s2t_transformer",
+            choices=["s2t_transformer", "convtransformer"],
+            help="version of frontend convolutional layers",
+        )
         # Transformer
         parser.add_argument(
             "--activation-fn",
@@ -430,6 +437,13 @@ class S2SpecTTransformerModel(S2STransformerMultitaskModelBase):
             metavar="N",
             help="# of channels in Conv1d subsampling layers",
         )
+        parser.add_argument(
+            "--conv-version",
+            type=str,
+            default="s2t_transformer",
+            choices=["s2t_transformer", "convtransformer"],
+            help="version of frontend convolutional layers",
+        )
         # Transformer
         parser.add_argument(
             "--activation-fn",
@@ -599,8 +613,10 @@ def base_s2st_transformer_encoder_architecture(args):
     args.encoder_freezing_updates = getattr(args, "encoder_freezing_updates", 0)
 
     # Convolutional subsampler
+    args.input_channels = getattr(args, "input_channels", 1)
     args.conv_kernel_sizes = getattr(args, "conv_kernel_sizes", "5,5")
     args.conv_channels = getattr(args, "conv_channels", 1024)
+    args.conv_version = getattr(args, "conv_version", "s2t_transformer")
     # Transformer
     args.encoder_embed_dim = getattr(args, "encoder_embed_dim", 512)
     args.encoder_ffn_embed_dim = getattr(args, "encoder_ffn_embed_dim", 2048)

--- a/fairseq/models/speech_to_text/modules/convolution.py
+++ b/fairseq/models/speech_to_text/modules/convolution.py
@@ -68,3 +68,59 @@ def infer_conv_output_dim(in_channels, input_dim, out_channels):
     x = x.transpose(1, 2)
     mb, seq = x.size()[:2]
     return x.contiguous().view(mb, seq, -1).size(-1)
+
+
+class Conv2dSubsampler(nn.Module):
+    """Convolutional subsampler: a stack of 2D convolution based on ESPnet implementation
+    (https://github.com/espnet/espnet)
+
+    Args:
+        input_channels (int): the number of input channels
+        input_feat_per_channel (int): encoder input dimension per input channel
+        conv_out_channels (int): the number of output channels of conv layer
+        encoder_embed_dim (int): encoder dimentions
+    """
+
+    def __init__(
+        self,
+        input_channels: int,
+        input_feat_per_channel: int,
+        conv_out_channels: int,
+        encoder_embed_dim: int,
+    ):
+        super().__init__()
+        assert input_channels == 1, input_channels
+        self.conv = torch.nn.Sequential(
+            torch.nn.Conv2d(
+                input_channels, conv_out_channels, 3, stride=2, padding=3 // 2
+            ),
+            torch.nn.ReLU(),
+            torch.nn.Conv2d(
+                conv_out_channels,
+                conv_out_channels,
+                3,
+                stride=2,
+                padding=3 // 2,
+            ),
+            torch.nn.ReLU(),
+        )
+        transformer_input_dim = infer_conv_output_dim(
+            input_channels, input_feat_per_channel, conv_out_channels
+        )
+        self.out = torch.nn.Linear(transformer_input_dim, encoder_embed_dim)
+
+    def forward(self, src_tokens, src_lengths):
+        B, T_i, C = src_tokens.size()
+        x = src_tokens.view(B, T_i, 1, C).transpose(1, 2).contiguous()
+        x = self.conv(x)
+        B, _, T_o, _ = x.size()
+        x = x.transpose(1, 2).transpose(0, 1).contiguous().view(T_o, B, -1)
+        x = self.out(x)
+
+        subsampling_factor = int(T_i * 1.0 / T_o + 0.5)
+        input_len_0 = (src_lengths.float() / subsampling_factor).ceil().long()
+        input_len_1 = x.size(0) * torch.ones([src_lengths.size(0)]).long().to(
+            input_len_0.device
+        )
+        input_lengths = torch.min(input_len_0, input_len_1)
+        return x, input_lengths

--- a/fairseq/models/speech_to_text/s2t_conformer.py
+++ b/fairseq/models/speech_to_text/s2t_conformer.py
@@ -12,8 +12,11 @@ import torch
 from fairseq import checkpoint_utils
 from fairseq.data.data_utils import lengths_to_padding_mask
 from fairseq.models import FairseqEncoder, register_model, register_model_architecture
-from fairseq.models.speech_to_text.s2t_transformer import (
+from fairseq.models.speech_to_text.modules.convolution import (
     Conv1dSubsampler,
+    Conv2dSubsampler,
+)
+from fairseq.models.speech_to_text.s2t_transformer import (
     S2TTransformerEncoder,
     S2TTransformerModel,
 )
@@ -39,12 +42,21 @@ class S2TConformerEncoder(FairseqEncoder):
         if args.no_scale_embedding:
             self.embed_scale = 1.0
         self.padding_idx = 1
-        self.subsample = Conv1dSubsampler(
-            args.input_feat_per_channel * args.input_channels,
-            args.conv_channels,
-            args.encoder_embed_dim,
-            [int(k) for k in args.conv_kernel_sizes.split(",")],
-        )
+        self.conv_version = args.conv_version
+        if self.conv_version == "s2t_transformer":
+            self.subsample = Conv1dSubsampler(
+                args.input_feat_per_channel * args.input_channels,
+                args.conv_channels,
+                args.encoder_embed_dim,
+                [int(k) for k in args.conv_kernel_sizes.split(",")],
+            )
+        elif self.conv_version == "convtransformer":
+            self.subsample = Conv2dSubsampler(
+                args.input_channels,
+                args.input_feat_per_channel,
+                256,
+                args.encoder_embed_dim,
+            )
         self.pos_enc_type = args.pos_enc_type
         if self.pos_enc_type == "rel_pos":
             self.embed_positions = RelPositionalEncoding(

--- a/fairseq/models/speech_to_text/s2t_conformer.py
+++ b/fairseq/models/speech_to_text/s2t_conformer.py
@@ -54,7 +54,7 @@ class S2TConformerEncoder(FairseqEncoder):
             self.subsample = Conv2dSubsampler(
                 args.input_channels,
                 args.input_feat_per_channel,
-                256,
+                args.conv_out_channels,
                 args.encoder_embed_dim,
             )
         self.pos_enc_type = args.pos_enc_type

--- a/fairseq/models/speech_to_text/s2t_transformer.py
+++ b/fairseq/models/speech_to_text/s2t_transformer.py
@@ -86,13 +86,19 @@ class S2TTransformerModel(FairseqEncoderDecoderModel):
             "--conv-kernel-sizes",
             type=str,
             metavar="N",
-            help="kernel sizes of Conv1d subsampling layers",
+            help="kernel sizes of Conv1d (s2t_transformer) subsampling layers",
         )
         parser.add_argument(
             "--conv-channels",
             type=int,
             metavar="N",
-            help="# of channels in Conv1d subsampling layers",
+            help="# of channels in Conv1d (s2t_transformer) subsampling layers",
+        )
+        parser.add_argument(
+            "--conv-out-channels",
+            type=int,
+            metavar="N",
+            help="# of channels in Conv2d (convtransformer) subsampling layers",
         )
         parser.add_argument(
             "--conv-version",
@@ -316,7 +322,7 @@ class S2TTransformerEncoder(FairseqEncoder):
             self.subsample = Conv2dSubsampler(
                 args.input_channels,
                 args.input_feat_per_channel,
-                256,
+                args.conv_out_channels,
                 args.encoder_embed_dim,
             )
 
@@ -449,8 +455,9 @@ def base_architecture(args):
     args.encoder_freezing_updates = getattr(args, "encoder_freezing_updates", 0)
     # Convolutional subsampler
     args.input_channels = getattr(args, "input_channels", 1)
-    args.conv_kernel_sizes = getattr(args, "conv_kernel_sizes", "5,5")
-    args.conv_channels = getattr(args, "conv_channels", 1024)
+    args.conv_kernel_sizes = getattr(args, "conv_kernel_sizes", "5,5")  # for Conv1d
+    args.conv_channels = getattr(args, "conv_channels", 1024)  # for Conv1d
+    args.conv_out_channels = getattr(args, "conv_out_channels", 256)  # for Conv2d
     args.conv_version = getattr(args, "conv_version", "s2t_transformer")
     # Transformer
     args.encoder_embed_dim = getattr(args, "encoder_embed_dim", 512)


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Added Conv2dSubsampler as a separate class. In the default setting, Conv1dSubsampler is used for`s2t_transformer.py` while Conv2dSubsampler is used for `convtransformer.py`. But later, it is found that Conv2dSubsampler is slightly better than Conv1dSubsampler regardless of the encoder type.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
