### PR TITLE
use src_lengths from net_input if possible if src_tokens in the input

### DIFF
--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -222,9 +222,13 @@ class SequenceGenerator(nn.Module):
         if "src_tokens" in net_input:
             src_tokens = net_input["src_tokens"]
             # length of the source text being the character length except EndOfSentence and pad
-            src_lengths = (
-                (src_tokens.ne(self.eos) & src_tokens.ne(self.pad)).long().sum(dim=1)
-            )
+            # if src_lengths exists in net_input (speech_to_text dataset case), then use it
+            if "src_lengths" in net_input:
+                src_lengths = net_input["src_lengths"]
+            else:
+                src_lengths = (
+                    (src_tokens.ne(self.eos) & src_tokens.ne(self.pad)).long().sum(dim=1)
+                )
         elif "source" in net_input:
             src_tokens = net_input["source"]
             src_lengths = (

--- a/fairseq/sequence_generator.py
+++ b/fairseq/sequence_generator.py
@@ -227,7 +227,9 @@ class SequenceGenerator(nn.Module):
                 src_lengths = net_input["src_lengths"]
             else:
                 src_lengths = (
-                    (src_tokens.ne(self.eos) & src_tokens.ne(self.pad)).long().sum(dim=1)
+                    (src_tokens.ne(self.eos) & src_tokens.ne(self.pad))
+                    .long()
+                    .sum(dim=1)
                 )
         elif "source" in net_input:
             src_tokens = net_input["source"]


### PR DESCRIPTION
Speech to text dataset provides its own src_lengths field as part of the `net_input`, because it uses a different way to pad input audio samples (!= dict.pad) and also does not contain eos token.

Because of this the existing code was computing src_lengths incorrectly: it set every seq length as the length of the minibatch i.e. max length. This was not affecting the model's generations, because src_lengths was used only if `match_src_length` set to true which we didn't do in the case of audio input.

Unpredictable behavior arise when we decide to use src_lengths for smth else during generation. This fix addresses the issue by re-using the src_lengths from net_input if possible in that if-else branch.

Unrelated to this fix, probably it is better to use 'features' or 'source' as the input field in speech to text dataset, because in this case the src_lengths will be recomputed correctly using the padding mask.