### PR TITLE
Support multitask for XMTransformer

### DIFF
--- a/fairseq/criterions/speech_to_speech_criterion.py
+++ b/fairseq/criterions/speech_to_speech_criterion.py
@@ -33,11 +33,15 @@ class MultitaskCriterion:
         self.multitask_criterion = OrderedDict()
         self.multitask_loss_weight = OrderedDict()
         for task_name, task_obj in multitask_tasks.items():
+            if task_obj.args.get_loss_weight(0) == 0:
+                logger.info(f"Skip {task_name} loss criterion")
+                continue
+
             rdrop_alpha_task = task_obj.args.rdrop_alpha
             if rdrop_alpha_task is None:
                 rdrop_alpha_task = rdrop_alpha
             self.rdrop_alpha_mtl = rdrop_alpha_task
-            logger.info(f"rdrop_alpha is set to {rdrop_alpha_task}")
+            logger.info(f"rdrop_alpha is set to {rdrop_alpha_task} for {task_name}")
 
             if task_obj.args.decoder_type == "ctc":
                 self.multitask_criterion[task_name] = CtcCriterion(


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Supported multi-task learning with aux task for XMTransformer.
So far, XMTransormer hasn't introduced the function because the model is pre-trained.
To do multi-task learning with XMTransormer based on this update, it is required to set `--criteiron` to `speech_to_unit` rather than `label_smoothed_cross_entropy`.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
