### PR TITLE
Fix Must-C data preprocessing

### DIFF
--- a/examples/speech_to_text/seg_mustc_data.py
+++ b/examples/speech_to_text/seg_mustc_data.py
@@ -7,12 +7,11 @@
 import argparse
 import logging
 from pathlib import Path
-import soundfile as sf
-from examples.speech_to_text.prep_mustc_data import (
-    MUSTC
-)
 
+import soundfile as sf
 from tqdm import tqdm
+
+from examples.speech_to_text.prep_mustc_data import MUSTC
 
 log = logging.getLogger(__name__)
 
@@ -23,9 +22,7 @@ def main(args):
     split = args.split
 
     cur_root = root / f"en-{lang}"
-    assert cur_root.is_dir(), (
-        f"{cur_root.as_posix()} does not exist. Skipped."
-    )
+    assert cur_root.is_dir(), f"{cur_root.as_posix()} does not exist. Skipped."
 
     dataset = MUSTC(root.as_posix(), lang, split)
     output = Path(args.output).absolute()
@@ -36,7 +33,7 @@ def main(args):
         sf.write(
             output / f"{utt_id}.wav",
             waveform.squeeze(0).numpy(),
-            samplerate=int(sample_rate)
+            samplerate=int(sample_rate),
         )
         f_text.write(text + "\n")
         f_wav_list.write(str(output / f"{utt_id}.wav") + "\n")

--- a/examples/speech_to_text/seg_mustc_data.py
+++ b/examples/speech_to_text/seg_mustc_data.py
@@ -26,16 +26,22 @@ def main(args):
 
     dataset = MUSTC(root.as_posix(), lang, split)
     output = Path(args.output).absolute()
-    output.mkdir(exist_ok=True)
-    f_text = open(output / f"{split}.{lang}", "w")
-    f_wav_list = open(output / f"{split}.wav_list", "w")
-    for waveform, sample_rate, _, text, _, utt_id in tqdm(dataset):
+    output.mkdir(parents=True, exist_ok=True)
+    if args.task == "asr":
+        f_text = open(output / f"{split}_{args.task}.en", "w")
+    else:
+        f_text = open(output / f"{split}_{args.task}.{lang}", "w")
+    f_wav_list = open(output / f"{split}_{args.task}.wav_list", "w")
+    for waveform, sample_rate, src_text, tgt_text, _, utt_id in tqdm(dataset):
         sf.write(
             output / f"{utt_id}.wav",
             waveform.squeeze(0).numpy(),
             samplerate=int(sample_rate),
         )
-        f_text.write(text + "\n")
+        if args.task == "asr":
+            f_text.write(src_text + "\n")
+        else:
+            f_text.write(tgt_text + "\n")
         f_wav_list.write(str(output / f"{utt_id}.wav") + "\n")
 
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
- Fixed calculation of input statistics. The default `--gcmvn-max-num` was too small. It didn't use the whole training samples to calculate the statistics.
- Supported waveform inputs + global cmvn.
- Fixed data filtering for dev and test sets. Previously, both dev and test sets were also filtered based on the input lengths (max=3000, min=5).
- Added a `src_text` column to manifests, which would be helpful for joint ASR+ST training.
- Support waveform segmentation, which is used for SimulEval, for streaming ASR

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
