### PR TITLE
Migrate hub loading for tts models in the config to be based on ust branch

### DIFF
--- a/fairseq/models/speech_to_text/hub_interface.py
+++ b/fairseq/models/speech_to_text/hub_interface.py
@@ -110,8 +110,10 @@ class S2THubInterface(nn.Module):
                 temp = tts_model_id.split(":")
                 if len(temp) == 2:
                     _repo, _id = temp
-                else:
+                elif len(temp) == 3:
                     _repo, _id = ":".join(temp[:2]), temp[2]
+                else:
+                    raise Exception("Invalid TTS model path")
                 tts_model = torch.hub.load(_repo, _id, verbose=False)
                 pred = (pred, tts_model.predict(pred, speaker=speaker))
         return pred

--- a/fairseq/models/speech_to_text/hub_interface.py
+++ b/fairseq/models/speech_to_text/hub_interface.py
@@ -107,7 +107,11 @@ class S2THubInterface(nn.Module):
             if tts_model_id is None:
                 logger.warning("TTS model configuration not found")
             else:
-                _repo, _id = tts_model_id.split(":")
+                temp = tts_model_id.split(":")
+                if len(temp) == 2:
+                    _repo, _id = temp
+                else:
+                    _repo, _id = ":".join(temp[:2]), temp[2]
                 tts_model = torch.hub.load(_repo, _id, verbose=False)
                 pred = (pred, tts_model.predict(pred, speaker=speaker))
         return pred


### PR DESCRIPTION
TSIA

Verified that all the 4 models and the new vocoder model added work as expected. 

- S2UT models - "xm_transformer_s2ut_hk-en" ,"xm_transformer_s2ut_en-hk"
- UnitY models - "xm_transformer_unity_hk-en", "xm_transformer_unity_en-hk"
- Hk vocoder - unit_hifigan_HK_layer12.km2500_frame_TAT-TTS 

The new model path will look like pytorch/fairseq:ust:unit_hifigan_HK_layer12.km2500_frame_TAT-TTS instead of pytorch/fairseq:unit_hifigan_HK_layer12.km2500_frame_TAT-TTS for the new models we add. he previous models will be left unchanged.