### PR TITLE
Expand the feat dims for "fbank80_w_utt_cmvn" input type

### DIFF
--- a/fairseq/models/speech_to_text/hub_interface.py
+++ b/fairseq/models/speech_to_text/hub_interface.py
@@ -42,7 +42,8 @@ class S2THubInterface(nn.Module):
             else:
                 import torchaudio.compliance.kaldi as kaldi
 
-                feat = kaldi.fbank(audio, num_mel_bins=80).numpy()  # 1 x T x D
+                feat = kaldi.fbank(audio, num_mel_bins=80).numpy()
+                feat = np.expand_dims(feat, axis=0)  # T x D -> 1 x T x D
         elif input_type in {"waveform", "standardized_waveform"}:
             if isinstance(audio, str):
                 feat, sr = get_wav(audio)  # C x T


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fix the feat dims issue for "fbank80_w_utt_cmvn" input and Tensor as the audio type. Issue is found during building hf demos for S2UT and UnitY Hok models:
For example, the input audio is torch.Size([1, 115200]), and then convert the feat shape from (718, 80) to (1, 718, 80)

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
