### PR TITLE
Optimize MuST-C preprocessing script

### DIFF
--- a/examples/speech_to_text/data_utils.py
+++ b/examples/speech_to_text/data_utils.py
@@ -106,7 +106,7 @@ def _load_files(paths: List[Path]):
     for path in paths:
         with open(path, 'rb') as handle:
             data.append(handle.read())
-    return data
+    return paths, data
 
 
 def create_zip(data_root: Path, zip_path: Path):
@@ -122,9 +122,9 @@ def create_zip(data_root: Path, zip_path: Path):
                     for i in range(0, len(paths), chunksize)
                 ]
                 for future in as_completed(futures):
-                    data = future.result()
-                    for path, data_ in zip(paths, data):
-                        f.writestr(path.name, data_)
+                    chunk_paths, chunk_data = future.result()
+                    for path, data in zip(chunk_paths, chunk_data):
+                        f.writestr(path.name, data)
                         pbar.update(1)
 
 

--- a/examples/speech_to_text/data_utils.py
+++ b/examples/speech_to_text/data_utils.py
@@ -3,11 +3,14 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 import csv
 from pathlib import Path
 import zipfile
 from functools import reduce
-from multiprocessing import cpu_count
+from multiprocessing import cpu_count, Pool
+from functools import partial
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Union
 import io
 
@@ -98,12 +101,47 @@ def extract_fbank_features(
     return features
 
 
+def _load_files(paths: List[Path]):
+    data = list()
+    for path in paths:
+        with open(path, 'rb') as handle:
+            data.append(handle.read())
+    return data
+
+
 def create_zip(data_root: Path, zip_path: Path):
     paths = list(data_root.glob("*.npy"))
     paths.extend(data_root.glob("*.flac"))
+    chunksize = 100
+    max_workers = (len(os.sched_getaffinity(0)) + 1) // 2
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as f:
-        for path in tqdm(paths):
-            f.write(path, arcname=path.name)
+        with tqdm(total=len(paths)) as pbar:
+            with ProcessPoolExecutor(max_workers) as exe:
+                futures = [
+                    exe.submit(_load_files, paths[i:(i + chunksize)])
+                    for i in range(0, len(paths), chunksize)
+                ]
+                for future in as_completed(futures):
+                    data = future.result()
+                    for path, data_ in zip(paths, data):
+                        f.writestr(path.name, data_)
+                        pbar.update(1)
+
+
+def _get_utt_length(_zip_path: Path, is_audio: bool, utt: Dict[str, Union[str, int]]):
+    with open(_zip_path, "rb") as f:
+        f.seek(utt['offset'])
+        byte_data = f.read(utt['file_size'])
+        assert len(byte_data) > 1
+        if is_audio:
+            assert is_sf_audio_data(byte_data), utt['utt_id']
+        else:
+            assert is_npy_data(byte_data), utt['utt_id']
+        byte_data_fp = io.BytesIO(byte_data)
+        if is_audio:
+            return sf.info(byte_data_fp).frames
+        else:
+            return np.load(byte_data_fp).shape[0]
 
 
 def get_zip_manifest(
@@ -112,25 +150,18 @@ def get_zip_manifest(
     _zip_path = Path.joinpath(zip_root or Path(""), zip_path)
     with zipfile.ZipFile(_zip_path, mode="r") as f:
         info = f.infolist()
-    paths, lengths = {}, {}
-    for i in tqdm(info):
-        utt_id = Path(i.filename).stem
-        offset, file_size = i.header_offset + 30 + len(i.filename), i.file_size
-        paths[utt_id] = f"{zip_path.as_posix()}:{offset}:{file_size}"
-        with open(_zip_path, "rb") as f:
-            f.seek(offset)
-            byte_data = f.read(file_size)
-            assert len(byte_data) > 1
-            if is_audio:
-                assert is_sf_audio_data(byte_data), i
-            else:
-                assert is_npy_data(byte_data), i
-            byte_data_fp = io.BytesIO(byte_data)
-            if is_audio:
-                lengths[utt_id] = sf.info(byte_data_fp).frames
-            else:
-                lengths[utt_id] = np.load(byte_data_fp).shape[0]
-    return paths, lengths
+    df = pd.DataFrame(info, columns=['zip_info'])
+    df['utt_id'] = df.zip_info.apply(lambda x: Path(x.filename).stem)
+    df['offset'] = df.zip_info.apply(lambda x: x.header_offset + 30 + len(x.filename))
+    df['file_size'] = df.zip_info.apply(lambda x: x.file_size)
+    df['path'] = df.apply(lambda x: f"{zip_path.as_posix()}:{x.offset}:{x.file_size}", axis=1)
+    _get_utt_length_ = partial(_get_utt_length, _zip_path, is_audio)
+    num_cpus = len(os.sched_getaffinity(0))
+    with Pool(num_cpus) as p:
+        df['length'] = list(tqdm(p.imap(
+            _get_utt_length_, df.to_dict('records'), chunksize=100
+        ), total=len(df)))
+    return dict(zip(df.utt_id, df.path)), dict(zip(df.utt_id, df.length))
 
 
 def gen_config_yaml(


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [X] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
I found the preprocessing script for MuST-C with `--use-audio-input` is really slow. Many processes are based on a massive for-loop, without any kind of parallelization. So, I decided to improve this script in different points of the code. Some of these also improve, indirectly, other speech-to-text preprocessing scripts.

Here, I list the improvements:

### YAML Loader

I changed the loader from `BaseLoader` to `CBaseLoader`, which reduces from 1:30 minutes to less than 10 seconds.

This improvement also applies the MuST-C preprocessing without `--use-audio-input`.


### Audio file conversion + saving to FLAC

This is by far the longest process in the script. After 1 hour, it just converted the 5% of the files in the en-de train split. After parallelizing it, using 16 CPUs, in 2 hours I converted the whole en-de split.


### Zip file creation

Zipping the converted audio files also takes a long time with the current code (>20 minutes). After parallelizing it, using 16 CPUs, it can be done in around 3 minutes.

This improves the `create_zip` from `data_utils.py`, and hence it also optimizes all the preprocessing scripts using it.


### Zip manifest

The current `get_zip_manifest` function takes around 8 minutes to execute. After parallelizing it, using 16 CPUs, it runs in less than 1 minute.

This improves the `get_zip_manifest` from `data_utils.py`, and hence it also optimizes all the preprocessing scripts using it.


### TSV manifest generation

Parallelizing this process with 16 CPUs, the execution time is reduced from around 7 minutes to 1-2 minutes.

This improvement also applies the MuST-C preprocessing without `--use-audio-input`.
