### PR TITLE
skipping invalid sized validation set

### DIFF
--- a/fairseq/data/data_utils_fast.pyx
+++ b/fairseq/data/data_utils_fast.pyx
@@ -112,6 +112,7 @@ cpdef list batch_by_size_fn(
     int64_t max_sentences,
     int32_t bsz_mult,
 ):
+    cdef int32_t target_index = 0
     cdef int32_t indices_len = indices.shape[0]
     cdef np.ndarray[int64_t, ndim=1] num_tokens_vec = np.zeros(indices_len,
                                                                dtype=np.int64)
@@ -120,6 +121,13 @@ cpdef list batch_by_size_fn(
     cdef int64_t pos
     for pos in range(indices_len):
         num_tokens_vec[pos] = num_tokens_fn(indices_view[pos])
+
+    for num_index in range(len(num_tokens_vec)):
+        if num_tokens_vec[num_index] <= max_tokens:
+            target_index = num_index
+            break
+    indices = indices[target_index:]
+    num_tokens_vec = num_tokens_vec[target_index:]
     return batch_by_size_vec(indices, num_tokens_vec, max_tokens,
         max_sentences, bsz_mult,)
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fixes # (issue).
Even though `skip_invalid_size_inputs_valid_test` was set to true, validation data samples with a length exceeding max_tokens are being taken. In fact, the entire validation data was taken into account, as opposed to skip the longer length samples. This PR will resolve the issue. It will choose just those samples whose length is shorter than the 'max_tokens' value.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
