### PR TITLE
Enable AzureML logging for validation too

### DIFF
--- a/fairseq_cli/train.py
+++ b/fairseq_cli/train.py
@@ -491,6 +491,11 @@ def validate(
             wandb_run_name=os.environ.get(
                 "WANDB_NAME", os.path.basename(cfg.checkpoint.save_dir)
             ),
+            azureml_logging=(
+                cfg.common.azureml_logging
+                if distributed_utils.is_master(cfg.distributed_training)
+                else False
+            ),
         )
 
         # create a new root metrics aggregator so validation metrics


### PR DESCRIPTION
# Before submitting

- [ ] (No, it's a minor edit) Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
The `azureml-logging` option is only working during the training loop, here: https://github.com/facebookresearch/fairseq/blob/ad3bec5a07962a994ac25ad1609ab926b13e0c0f/fairseq_cli/train.py#L298

This option does not work during the validation loop, and metrics don't appear in AzureML, because `progress_bar` doesn't get the `azureml_logging` argument:
https://github.com/facebookresearch/fairseq/blob/ad3bec5a07962a994ac25ad1609ab926b13e0c0f/fairseq_cli/train.py#L491

This PR fixes that issue. I tested the patch on AzureML.

## Did you have fun?
Yes!
