### PR TITLE
fix #4708

### DIFF
--- a/fairseq/modules/sinusoidal_positional_embedding.py
+++ b/fairseq/modules/sinusoidal_positional_embedding.py
@@ -97,7 +97,7 @@ class SinusoidalPositionalEmbedding(nn.Module):
         if self.onnx_trace:
             flat_embeddings = self.weights.detach().index_select(0, positions.view(-1))
             embedding_shape = torch.cat(
-                (bsz.view(1), seq_len.view(1), torch.tensor([-1], dtype=torch.long))
+                (bsz, seq_len, torch.tensor([-1], dtype=torch.long))
             )
             embeddings = torch.onnx.operators.reshape_from_tensor_shape(
                 flat_embeddings, embedding_shape


### PR DESCRIPTION
after changes in #4708, the affected params are not tensor, hence we can't use view(.).