### PR TITLE
Average losses with the correct ntokens due to prefix-size > 0

### DIFF
--- a/fairseq/criterions/label_smoothed_cross_entropy.py
+++ b/fairseq/criterions/label_smoothed_cross_entropy.py
@@ -79,6 +79,7 @@ class LabelSmoothedCrossEntropyCriterion(FairseqCriterion):
         """
         net_output = model(**sample["net_input"])
         loss, nll_loss = self.compute_loss(model, net_output, sample, reduce=reduce)
+        sample["ntokens"] -= self.ignore_prefix_size * sample["target"].size(0)
         sample_size = (
             sample["target"].size(0) if self.sentence_avg else sample["ntokens"]
         )

--- a/fairseq/criterions/label_smoothed_cross_entropy_latency_augmented.py
+++ b/fairseq/criterions/label_smoothed_cross_entropy_latency_augmented.py
@@ -111,6 +111,7 @@ class LatencyAugmentedLabelSmoothedCrossEntropyCriterion(
 
         loss += latency_loss
 
+        sample["ntokens"] -= self.ignore_prefix_size * sample["target"].size(0)
         sample_size = (
             sample["target"].size(0) if self.sentence_avg else sample["ntokens"]
         )

--- a/fairseq/criterions/label_smoothed_cross_entropy_with_alignment.py
+++ b/fairseq/criterions/label_smoothed_cross_entropy_with_alignment.py
@@ -46,6 +46,7 @@ class LabelSmoothedCrossEntropyCriterionWithAlignment(
         """
         net_output = model(**sample["net_input"])
         loss, nll_loss = self.compute_loss(model, net_output, sample, reduce=reduce)
+        sample["ntokens"] -= self.ignore_prefix_size * sample["target"].size(0)
         sample_size = (
             sample["target"].size(0) if self.sentence_avg else sample["ntokens"]
         )

--- a/fairseq/criterions/label_smoothed_cross_entropy_with_ctc.py
+++ b/fairseq/criterions/label_smoothed_cross_entropy_with_ctc.py
@@ -68,6 +68,7 @@ class LabelSmoothedCrossEntropyWithCtcCriterion(LabelSmoothedCrossEntropyCriteri
             )
         loss += ctc_loss
 
+        sample["ntokens"] -= self.ignore_prefix_size * sample["target"].size(0)
         sample_size = (
             sample["target"].size(0) if self.sentence_avg else sample["ntokens"]
         )

--- a/fairseq/criterions/label_smoothed_cross_entropy_with_rdrop.py
+++ b/fairseq/criterions/label_smoothed_cross_entropy_with_rdrop.py
@@ -71,6 +71,7 @@ class RdropLabelSmoothedCrossEntropyCriterion(LabelSmoothedCrossEntropyCriterion
         loss, nll_loss, rdrop_kl_loss = self.compute_loss(
             model, net_output, sample, reduce=reduce
         )
+        sample["ntokens"] -= self.ignore_prefix_size * sample["target"].size(0)
         sample_size = (
             sample["target"].size(0) if self.sentence_avg else sample["ntokens"]
         )

--- a/fairseq/criterions/speech_to_speech_criterion.py
+++ b/fairseq/criterions/speech_to_speech_criterion.py
@@ -197,6 +197,7 @@ class SpeechToUnitMultitaskTaskCriterion(
         loss, nll_loss, rdrop_kl_loss = self.compute_loss(
             model, [net_output], sample, reduce=reduce
         )
+        sample["ntokens"] -= self.ignore_prefix_size * sample["target"].size(0)
         sample_size = (
             sample["target"].size(0) if self.sentence_avg else sample["ntokens"]
         )
@@ -301,6 +302,7 @@ class SpeechToUnit2passMultitaskTaskCriterion(SpeechToUnitMultitaskTaskCriterion
             model, [net_output], sample, reduce=reduce
         )
 
+        sample["ntokens"] -= self.ignore_prefix_size * sample["target"].size(0)
         sample_size = (
             sample["target"].size(0) if self.sentence_avg else sample["ntokens"]
         )


### PR DESCRIPTION
# Before submitting

❌ Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
✅ Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
❌ Did you make sure to update the docs?
❌ Did you write any new necessary tests?

## What does this PR do?

Accounts for the fewer `ntokens` in `label_smoothed_cross_entropy` (and other related criteria) due to `--prefix-size`.
Without it, the averaging of the loss is done with `nsentences * args.prefix_size` more tokens, which results in slightly lower values.
