### PR TITLE
Update get_available_activation_fns to match get_activation_fn

### DIFF
--- a/fairseq/utils.py
+++ b/fairseq/utils.py
@@ -575,11 +575,13 @@ def get_activation_fn(activation: str) -> Callable:
 def get_available_activation_fns() -> List:
     return [
         "relu",
+        "relu_squared",
         "gelu",
         "gelu_fast",  # deprecated
         "gelu_accurate",
         "tanh",
         "linear",
+        "swish",
     ]
 
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?

Fixes a discrepancy between the `get_activation_fn()` method and the `get_available_activation_fns()` method (enabling "swish" and "relu_squared" as available). 

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
