### PR TITLE
Update references to Flashlight bindings

### DIFF
--- a/examples/data2vec/README.md
+++ b/examples/data2vec/README.md
@@ -91,12 +91,12 @@ $ fairseq-hydra-train \
 There are other config files in the config/finetuning directory that can be used to fine-tune on other splits.
 You can specify the right config via the `--config-name` parameter.
 
-Decoding with a language model during training requires flashlight [python bindings](https://github.com/facebookresearch/flashlight/tree/master/bindings/python) (previously called [wav2letter](https://github.com/facebookresearch/wav2letter).
+Decoding with a language model during training requires Flashlight Text [Python bindings](https://github.com/flashlight/text/#readme) (previously called [wav2letter](https://github.com/facebookresearch/wav2letter).
 If you want to use a language model, add `+criterion.wer_args='[/path/to/kenlm, /path/to/lexicon, 2, -1]'` to the command line.
 
 ### Evaluating a CTC model:
 
-Evaluating a CTC model with a language model requires [flashlight python bindings](https://github.com/facebookresearch/flashlight/tree/master/bindings/python) (previously called [wav2letter](https://github.com/facebookresearch/wav2letter) to be installed.
+Evaluating a CTC model with a language model requires [Flashlight Text Python bindings](https://github.com/flashlight/text/#readme) (previously called [wav2letter](https://github.com/facebookresearch/wav2letter) to be installed.
 
 Fairseq transformer language model used in the wav2vec 2.0 paper can be obtained from the [wav2letter model repository](https://github.com/facebookresearch/wav2letter/tree/master/recipes/sota/2019).
 Be sure to upper-case the language model vocab after downloading it.

--- a/examples/speech_recognition/README.md
+++ b/examples/speech_recognition/README.md
@@ -34,8 +34,8 @@ sclite -r ${RES_DIR}/ref.word-checkpoint_last.pt-${SET}.txt -h ${RES_DIR}/hypo.w
 ```
 `Sum/Avg` row from first table of the report has WER
 
-## Using flashlight (previously called [wav2letter](https://github.com/facebookresearch/wav2letter)) components
-[flashlight](https://github.com/facebookresearch/flashlight) now has integration with fairseq. Currently this includes:
+## Using Flashlight (previously called [wav2letter](https://github.com/facebookresearch/wav2letter)) components
+[Flashlight Text](https://github.com/flashlight/text) and [Flashlight Sequence](https://github.com/flashlight/sequence) now have integration with fairseq. Currently this includes:
 
 * AutoSegmentationCriterion (ASG)
 * flashlight-style Conv/GLU model

--- a/examples/speech_recognition/README.md
+++ b/examples/speech_recognition/README.md
@@ -41,11 +41,7 @@ sclite -r ${RES_DIR}/ref.word-checkpoint_last.pt-${SET}.txt -h ${RES_DIR}/hypo.w
 * flashlight-style Conv/GLU model
 * flashlight's beam search decoder
 
-To use these, follow the instructions on [this page](https://github.com/flashlight/flashlight/tree/e16682fa32df30cbf675c8fe010f929c61e3b833/bindings/python) to install python bindings. **Flashlight v0.3.2** must be used to install the bindings. Running:
-```
-git clone --branch v0.3.2 https://github.com/flashlight/flashlight
-```
-will properly clone and check out this version.
+**See the respective instructions for [Flashlight Text](https://github.com/flashlight/text#readme) and [Flashlight Sequence](https://github.com/flashlight/sequence#readme) to get started.**
 
 ## Training librispeech data (flashlight style, Conv/GLU + ASG loss)
 Training command:

--- a/examples/speech_recognition/new/decoders/flashlight_decoder.py
+++ b/examples/speech_recognition/new/decoders/flashlight_decoder.py
@@ -42,9 +42,9 @@ try:
     from flashlight.lib.text.dictionary import create_word_dict, load_words
 except ImportError:
     warnings.warn(
-        "flashlight python bindings are required to use this functionality. "
+        "Flashlight Text python bindings are required to use this functionality. "
         "Please install from "
-        "https://github.com/facebookresearch/flashlight/tree/master/bindings/python"
+        "https://github.com/flashlight/text/#readme"
     )
     LM = object
     LMState = object

--- a/examples/speech_recognition/w2l_decoder.py
+++ b/examples/speech_recognition/w2l_decoder.py
@@ -40,7 +40,7 @@ try:
     )
 except:
     warnings.warn(
-        "flashlight python bindings are required to use this functionality. Please install from https://github.com/facebookresearch/flashlight/tree/master/bindings/python"
+        "Flashlight python bindings are required to use this functionality. Please install from https://github.com/flashlight/text/#readme and https://github.com/flashlight/sequence#readme"
     )
     LM = object
     LMState = object

--- a/examples/wav2vec/README.md
+++ b/examples/wav2vec/README.md
@@ -175,12 +175,12 @@ You can specify the right config via the `--config-name` parameter.
 Note: you can simulate 24 GPUs by using k GPUs and adding command line parameters (before `--config-dir`)
 `distributed_training.distributed_world_size=k` `+optimization.update_freq='[x]'` where x = 24/k
 
-Decoding with a language model during training requires flashlight [python bindings](https://github.com/facebookresearch/flashlight/tree/master/bindings/python) (previously called [wav2letter](https://github.com/facebookresearch/wav2letter).
+Decoding with a language model during training requires the [Flashlight Text Python bindings](https://github.com/flashlight/text#readme) (previously called [wav2letter](https://github.com/facebookresearch/wav2letter).
 If you want to use a language model, add `+criterion.wer_args='[/path/to/kenlm, /path/to/lexicon, 2, -1]'` to the command line.
 
 ### Evaluating a CTC model
 
-Evaluating a CTC model with a language model requires [flashlight python bindings](https://github.com/facebookresearch/flashlight/tree/master/bindings/python) (previously called [wav2letter](https://github.com/facebookresearch/wav2letter) to be installed.
+Evaluating a CTC model with a language model requires the [Flashlight Text Python bindings](https://github.com/flashlight/text#readme) (previously called [wav2letter](https://github.com/facebookresearch/wav2letter) to be installed.
 
 Fairseq transformer language model used in the wav2vec 2.0 paper can be obtained from the [wav2letter model repository](https://github.com/facebookresearch/wav2letter/tree/master/recipes/sota/2019).
 Be sure to upper-case the language model vocab after downloading it.


### PR DESCRIPTION
Flashlight bindings for beam search decoding now live in https://github.com/flashlight/text#readme, and bindings for Viterbi algorithm implementations and ASG loss live in https://github.com/flashlight/sequence#readme.

Update documentation/logs throughout to point to these new repos, and to remove references to https://github.com/flashlight/flashlight, which no longer contains bindings.
