### PR TITLE
Add "autoregressive" option to "HubertAsrConfig"

### DIFF
--- a/fairseq/models/hubert/hubert_asr.py
+++ b/fairseq/models/hubert/hubert_asr.py
@@ -136,6 +136,13 @@ class HubertAsrConfig(FairseqDataclass):
     )
     normalize: bool = II("task.normalize")
     data: str = II("task.data")
+    autoregressive: bool = field(
+        default=False,
+        metadata={
+            "help": "required for autoregressive decoders (like seq2seq models); "
+            "adds 'prev_output_tokens' to input and appends eos to target"
+        },
+    )
 
     # this holds the loaded hubert args
     w2v_args: Any = None


### PR DESCRIPTION
Add "autoregressive" option to "fairseq/models/hubert/hubert_asr.py:HubertAsrConfig" to load model from hubert checkpoint normally.

```python
autoregressive: bool = field(
    default=False,
    metadata={
        "help": "required for autoregressive decoders (like seq2seq models); "
        "adds 'prev_output_tokens' to input and appends eos to target"
    },
)
```

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes [#4916](https://github.com/facebookresearch/fairseq/issues/4916).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
