### PR TITLE
fix a typo in the fine-tuning cmd at the roberta glue example

### DIFF
--- a/examples/roberta/README.glue.md
+++ b/examples/roberta/README.glue.md
@@ -19,7 +19,7 @@ Example fine-tuning cmd for `RTE` task
 ```bash
 ROBERTA_PATH=/path/to/roberta/model.pt
 
-CUDA_VISIBLE_DEVICES=0 fairseq-hydra-train -config-dir examples/roberta/config/finetuning --config-name rte \
+CUDA_VISIBLE_DEVICES=0 fairseq-hydra-train --config-dir examples/roberta/config/finetuning --config-name rte \
 task.data=RTE-bin checkpoint.restore_file=$ROBERTA_PATH
 ```
 


### PR DESCRIPTION
## What does this PR do?
At the fine-tuning example for roberta on the glue dataset, the fine-tuning command was missing a `-` before the config-dir (was `-config-dir` instead of `--config-dir`).

This caused this error to occur:
`fairseq-hydra-train: error: argument --cfg/-c: invalid choice: 'onfig-dir' (choose from 'job', 'hydra', 'all')` , since fairseq-hydra-train interpret `-config-dir` as the flag `-c`(= `--cfg` from [Hydra docs](https://hydra.cc/docs/advanced/hydra-command-line-flags/#internaldocs-banner))
