### PR TITLE
Fix minor typos in getting started doc

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -42,7 +42,7 @@ remove the BPE continuation markers and detokenize the output.
     P-0     -0.0763 -0.1849 -0.0956 -0.0946 -0.0735 -0.1150 -0.1301 -0.0042 -0.0321 -0.0171 -0.0052 -0.0062 -0.0015
 
 This generation script produces three types of outputs: a line prefixed
-with *O* is a copy of the original source sentence; *H* is the
+with *S* is a copy of the original source sentence; *H* is the
 hypothesis along with an average log-likelihood; and *P* is the
 positional score per token position, including the
 end-of-sentence marker which is omitted from the text.
@@ -83,7 +83,7 @@ This will write binarized data that can be used for model training to
 Training
 --------
 
-Use :ref:`fairseq-train` to train a new model. Here a few example settings that work
+Use :ref:`fairseq-train` to train a new model. Here are a few example settings that work
 well for the IWSLT 2014 dataset:
 
 .. code-block:: console

--- a/docs/tutorial_classifying_names.rst
+++ b/docs/tutorial_classifying_names.rst
@@ -23,7 +23,7 @@ This tutorial covers:
 
 The original tutorial provides raw data, but we'll work with a modified version
 of the data that is already tokenized into characters and split into separate
-train, valid and test sets.
+train, validation and test sets.
 
 Download and extract the data from here:
 `tutorial_names.tar.gz <https://dl.fbaipublicfiles.com/fairseq/data/tutorial_names.tar.gz>`_


### PR DESCRIPTION
This PR fixes some minor typos I saw while going through the documentation.

