### PR TITLE
fix training crash when --skip-remainder-batch=True

### DIFF
--- a/fairseq/data/iterators.py
+++ b/fairseq/data/iterators.py
@@ -524,7 +524,7 @@ class EpochBatchIterator(EpochBatchIterating):
             # TODO: Below is a lazy implementation which discard the final batch regardless
             # of whether it is a full batch or not.
 
-            total_num_itrs = len(self.epoch_batch_sampler) - 1
+            total_num_itrs = len(itr) - 1
             itr.take(total_num_itrs)
             logger.info(f"skip final residual batch, total_num_itrs = {total_num_itrs}")
 


### PR DESCRIPTION
When --skip-remainder-batch=True, restoring training from a checkpoint may crash. For example, each epoch has 10k steps, training stops and saves at the 8k-th step. When restoring training, initial_offset=8k in the Line 493, len(self.epoch_batch_sampler) will become 2k. Then itr.take(1999) in the Line 528 and self._itr.take(max(1999 - 10k, 0)) in the Line 81, making an empty dataset. The main training loop will crash.