### PR TITLE
Updated CircleCI, Actions and Lints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ install_linux_dep: &install_linux_dep
           echo "Installing torch==$PYTORCH_VERSION and torchvision==$TORCHVISION_VERSION from $PYTORCH_INDEX"
           pip install -v --progress-bar off torch==$PYTORCH_VERSION torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
         fi
+        python -c 'import torch; print("PyTorch Version:", torch.__version__)'
+        python -c 'import torchvision; print("TorchVision Version:", torchvision.__version__)'
+        python -c 'import torch; print("CUDA:", torch.cuda.is_available())'
 
 install_repo: &install_repo
   - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,35 +5,53 @@ version: 2.1
 # Environments to run the jobs in
 # -------------------------------------------------------------------------------------
 gpu: &gpu
-  environment:
-    CUDA_VERSION: "11.2"
   machine:
-    image: ubuntu-2004-cuda-11.2:202103-01
+    image: linux-cuda-11:2023.02.1
   resource_class: gpu.nvidia.medium.multi
 
+version_parameters: &version_parameters
+  parameters:
+    pytorch_version:
+      type: string
+    torchvision_version:
+      type: string
+    pytorch_index:
+      type: string
+      # use test wheels index to have access to RC wheels
+      # https://download.pytorch.org/whl/test/torch_test.html
+      default: "https://download.pytorch.org/whl/torch_stable.html"
+    python_version: # NOTE: only affects linux
+      type: string
+      default: '3.10.6'
+    cuda_version:
+      type: string
+      default: '11.6'
+
+  environment:
+    PYTORCH_VERSION: << parameters.pytorch_version >>
+    TORCHVISION_VERSION: << parameters.torchvision_version >>
+    PYTORCH_INDEX: << parameters.pytorch_index >>
+    PYTHON_VERSION: << parameters.python_version>>
+    CUDA_VERSION: << parameters.cuda_version >>
 
 # -------------------------------------------------------------------------------------
 # Re-usable commands
 # -------------------------------------------------------------------------------------
 cache_key: &cache_key cache-key-{{ .Environment.CIRCLE_JOB }}-{{ checksum ".circleci/config.yml" }}-{{ checksum "setup.py"}}
 
-install_dep_pt1_10: &install_dep_pt1_10
+install_linux_dep: &install_linux_dep
   - run:
-      name: Install Pytorch Dependencies
+      name: Install Dependencies
       command: |
-        source activate fairseq
-        pip install --upgrade setuptools
-        pip install torch==1.10.1+cu111 torchaudio==0.10.1+cu111 -f https://download.pytorch.org/whl/torch_stable.html
-        python -c 'import torch; print("Torch version:", torch.__version__)'
-
-install_dep_pt1_12: &install_dep_pt1_12
-  - run:
-      name: Install Pytorch Dependencies
-      command: |
-        source activate fairseq
-        pip install --upgrade setuptools
-        pip install torch==1.12.1+cu116 torchaudio==0.12.1+cu116 -f https://download.pytorch.org/whl/torch_stable.html
-        python -c 'import torch; print("Torch version:", torch.__version__)'
+        if [[ "$PYTORCH_VERSION" == "master" ]]; then
+                  echo "Installing torch/torchvision from $PYTORCH_INDEX"
+                  # Remove first, in case it's in the CI cache
+                  pip uninstall -y torch torchvision
+                  pip install -v --progress-bar off --pre torch torchvision --extra-index-url $PYTORCH_INDEX
+        else
+          echo "Installing torch==$PYTORCH_VERSION and torchvision==$TORCHVISION_VERSION from $PYTORCH_INDEX"
+          pip install -v --progress-bar off torch==$PYTORCH_VERSION torchvision==$TORCHVISION_VERSION -f $PYTORCH_INDEX
+        fi
 
 install_repo: &install_repo
   - run:
@@ -71,58 +89,59 @@ create_conda_env: &create_conda_env
         source $BASH_ENV
         if [ ! -d ~/miniconda/envs/fairseq ]
         then
-          conda create -y -n fairseq python=3.8
+          conda create -y -n fairseq python=<< parameters.python_version >>
         fi
         source activate fairseq
         python --version
         pip install --upgrade pip
+
+select_cuda: &select_cuda
+  - run:
+      name: Select CUDA
+      command: |
+        sudo update-alternatives --set cuda /usr/local/cuda-<< parameters.cuda_version >>
 # -------------------------------------------------------------------------------------
 # Jobs to run
 # -------------------------------------------------------------------------------------
 
 jobs:
-
-  gpu_tests_pt1_10:
+  linux_gpu_tests:
     <<: *gpu
+    <<: *version_parameters
 
     working_directory: ~/fairseq-py
 
     steps:
       - checkout
+      - <<: *select_cuda
       - <<: *check_nvidia_driver
       - <<: *create_conda_env
       - restore_cache:
           key: *cache_key
-      - <<: *install_dep_pt1_10
+      - <<: *install_linux_dep
       - save_cache:
           paths:
             - ~/miniconda/
           key: *cache_key
       - <<: *install_repo
       - <<: *run_unittests
-
-  gpu_tests_pt1_12:
-    <<: *gpu
-
-    working_directory: ~/fairseq-py
-
-    steps:
-      - checkout
-      - <<: *check_nvidia_driver
-      - <<: *create_conda_env
-      - restore_cache:
-          key: *cache_key
-      - <<: *install_dep_pt1_12
       - save_cache:
           paths:
-            - ~/miniconda/
-          key: *cache_key
-      - <<: *install_repo
-      - <<: *run_unittests
+            - /opt/circleci/.pyenv
+            - ~/.torch
+          key: cache-{{ arch }}-<< parameters.pytorch_version >>-{{ .Branch }}-20230227
 
 workflows:
   version: 2
   build:
     jobs:
-      - gpu_tests_pt1_12
-      - gpu_tests_pt1_10
+      - linux_gpu_tests:
+          name: linux_gpu_tests_pytorch1.12
+          pytorch_version: '1.12.1+cu116'
+          torchvision_version: '0.13.1+cu116'
+          cuda_version: '11.6'
+      - linux_gpu_tests:
+          name: linux_gpu_tests_pytorch1.13
+          pytorch_version: '1.13.1+cu116'
+          torchvision_version: '0.14.1+cu116'
+          cuda_version: '11.6'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,15 @@ jobs:
       max-parallel: 4
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
 
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       max-parallel: 4
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout-repo-content
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -76,7 +76,7 @@ jobs:
           ref: ${{ needs.get_next_version.outputs.branch_name }}
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 
@@ -89,7 +89,7 @@ jobs:
           python3 -m pip install setuptools wheel twine torch
           python3 setup.py sdist
  
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
 
@@ -107,7 +107,7 @@ jobs:
           ref: ${{ needs.get_next_version.outputs.branch_name }}
 
       - name: Install Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
 
@@ -131,7 +131,7 @@ jobs:
           CIBW_ENVIRONMENT: "PIP_ONLY_BINARY=numpy"
           CIBW_SKIP: "*musllinux*"
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           path: dist
 
@@ -140,7 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_wheels, create_sdist, get_next_version]
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: artifact
           path: dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,13 +17,13 @@ repos:
     -   id: end-of-file-fixer
 
 -   repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 23.1.0
     hooks:
     - id: black
-      language_version: python3.8
+      language_version: python3.10
 
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 6.0.0
     hooks:
     -   id: flake8
         args: [
@@ -32,7 +32,7 @@ repos:
         ]
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         exclude: README.md

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ import sys
 from setuptools import Extension, find_packages, setup
 from torch.utils import cpp_extension
 
-if sys.version_info < (3, 6):
-    sys.exit("Sorry, Python >= 3.6 is required for fairseq.")
+if sys.version_info < (3, 8):
+    sys.exit("Sorry, Python >= 3.8 is required for fairseq.")
 
 
 def write_version_py():
@@ -169,9 +169,9 @@ def do_setup(package_data):
         classifiers=[
             "Intended Audience :: Science/Research",
             "License :: OSI Approved :: MIT License",
-            "Programming Language :: Python :: 3.6",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
+            "Programming Language :: Python :: 3.10",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
         ],
         long_description=readme,
@@ -179,9 +179,9 @@ def do_setup(package_data):
         install_requires=[
             "cffi",
             "cython",
-            "hydra-core>=1.0.7,<1.1",
+            "hydra-core>=1.2.0,<1.3.2",
             "omegaconf<2.1",
-            "numpy>=1.21.3",
+            "numpy>=1.23.5",
             "regex",
             "sacrebleu>=1.4.12",
             "torch>=1.13",


### PR DESCRIPTION
- [X] Python <3.8 versions deleted (Deprecated 27 Jun 2023)
- [X] Python 3.10.6 (added as default) (CircleCI images have 3.10.6)
- [X] Pytorch <1.12 delete. Deprecated (https://pytorch.org/blog/deprecation-cuda-python-support/)
- [X] Updated linux-cuda-11:2023.02.1 GPU https://discuss.circleci.com/t/cuda-11-8-gpu-cuda-image-any-plans/47240/3
- [X] New image circleCI Cuda 11.8 and they are working to CUDA 12. https://discuss.circleci.com/t/cuda-11-8-gpu-cuda-image-any-plans/47240/4
- [X] Updated test compatible with CUDA and Pytorch > 1.10
- [X] Unified workflow github and CircleCI python versions: Python 3.10.6
- [X] Added CUDA variable on CircleCI: You now can select CUDA VERSION.
- [X] Ready For Pytorch 2.0 and CUDA 12.0/12.1 CircleCI(CircleCI working on release cuda 12 images at the end of the month)
- [X] Delete pytorch <1.12. Deprecation: https://pytorch.org/blog/deprecation-cuda-python-support/

