### PR TITLE
add missing user_dir to finetunning config

### DIFF
--- a/examples/data2vec/config/vision/finetuning/mae_imagenet_clean.yaml
+++ b/examples/data2vec/config/vision/finetuning/mae_imagenet_clean.yaml
@@ -6,7 +6,8 @@ common:
   log_interval: 200
   tensorboard_logdir: tb
   fp16_no_flatten_grads: true
-
+  user_dir: ${env:PWD}/examples/data2vec
+  
 checkpoint:
   save_interval: 1
   save_interval_updates: 25000

--- a/examples/data2vec/config/vision/finetuning/mae_imagenet_huge_clean.yaml
+++ b/examples/data2vec/config/vision/finetuning/mae_imagenet_huge_clean.yaml
@@ -6,6 +6,7 @@ common:
   log_interval: 200
   tensorboard_logdir: tb
   fp16_no_flatten_grads: true
+  user_dir: ${env:PWD}/examples/data2vec
 
 checkpoint:
   save_interval: 1

--- a/examples/data2vec/config/vision/finetuning/mae_imagenet_large_clean.yaml
+++ b/examples/data2vec/config/vision/finetuning/mae_imagenet_large_clean.yaml
@@ -6,7 +6,8 @@ common:
   log_interval: 200
   tensorboard_logdir: tb
   fp16_no_flatten_grads: true
-
+  user_dir: ${env:PWD}/examples/data2vec
+  
 checkpoint:
   save_interval: 1
   save_interval_updates: 25000


### PR DESCRIPTION
## What does this PR do?
`user_dir: ${env:PWD}/examples/data2vec` is missing in the finetunings configs, without this config the data2vec models are not registered ([here](https://github.com/facebookresearch/fairseq/blob/0338cdc3094ca7d29ff4d36d64791f7b4e4b5e6e/fairseq_cli/train.py#L48)) to `TASK_DATACLASS_REGISTRY` and the model can not be loaded.


## Did you have fun?
:)  I did :) very flexible code :-o

I think it is related to @alexeib 
