### PR TITLE
fix variable naming bug

### DIFF
--- a/fairseq/data/audio/raw_audio_dataset.py
+++ b/fairseq/data/audio/raw_audio_dataset.py
@@ -171,7 +171,7 @@ class RawAudioDataset(FairseqDataset):
         return out
 
     def _get_mask_indices_dims(self, size, padding=0, dilation=1):
-        if size not in self.feature_encoder_spec:
+        if size not in self._features_size_map:
             L_in = size
             for (_, kernel_size, stride) in self.feature_encoder_spec:
                 L_out = L_in + 2 * padding - dilation * (kernel_size - 1) - 1


### PR DESCRIPTION
The function `_get_mask_indices_dims` used the wrong variable when checking if a length was already cached.  This will increase performance
