### PR TITLE
`librosa.filters.mel()` requires keyword args

### DIFF
--- a/examples/speech_synthesis/generate_waveform.py
+++ b/examples/speech_synthesis/generate_waveform.py
@@ -90,7 +90,7 @@ def dump_result(
     if args.dump_attentions:
         attn_dir = out_root / "attn"
         attn_dir.mkdir(exist_ok=True, parents=True)
-        np.save(attn_dir / f"{sample_id}.npy", attn.numpy())
+        np.save(attn_dir / f"{sample_id}.npy", attn)
     if args.dump_eos_probs and not is_na_model:
         eos_dir = out_root / "eos"
         eos_dir.mkdir(exist_ok=True, parents=True)

--- a/fairseq/data/audio/audio_utils.py
+++ b/fairseq/data/audio/audio_utils.py
@@ -340,7 +340,7 @@ def get_mel_filters(
         import librosa
     except ImportError:
         raise ImportError("Please install librosa: pip install librosa")
-    basis = librosa.filters.mel(sample_rate, n_fft, n_mels, f_min, f_max)
+    basis = librosa.filters.mel(sr=sample_rate, n_fft=n_fft, n_mels=n_mels, fmin=f_min, fmax=f_max)
     return torch.from_numpy(basis).float()
 
 


### PR DESCRIPTION
- [librosa v0.9.0 implements keyword only arguments throughout the package.](https://github.com/librosa/librosa/pull/1431) Calling `librosa.filters.mel()` needs keywords `sr`, `n_fft`, etc. The order of keywords is the same as v0.8.1, so should be compatible with this change. 
- `postprocess_results()` converts `attr` into a NumPy array, but `dump_result()` expects it as a Torch tensor.