### PR TITLE
[ASR] Fix lexicon free decoder integration with wav2letter

### DIFF
--- a/examples/speech_recognition/new/decoders/flashlight_decoder.py
+++ b/examples/speech_recognition/new/decoders/flashlight_decoder.py
@@ -40,6 +40,7 @@ try:
         Trie,
     )
     from flashlight.lib.text.dictionary import create_word_dict, load_words
+    from flashlight.lib.text.dictionary import Dictionary as flDictionary
 except ImportError:
     warnings.warn(
         "flashlight python bindings are required to use this functionality. "
@@ -102,8 +103,9 @@ class KenLMDecoder(BaseDecoder):
         else:
             assert self.unitlm, "Lexicon-free decoding requires unit LM"
 
-            d = {w: [[w]] for w in tgt_dict.symbols}
-            self.word_dict = create_word_dict(d)
+            self.word_dict = flDictionary()
+            for sym in tgt_dict.symbols:
+                self.word_dict.add_entry(sym, tgt_dict.index(sym))
             self.lm = KenLM(cfg.lmpath, self.word_dict)
             self.decoder_opts = LexiconFreeDecoderOptions(
                 beam_size=cfg.beam,


### PR DESCRIPTION
The index of symbols in token dict and word dict should be the same for lexicon free decoder to work. This PR fixes it. 

Tested on Librispeech using an n-gram character LM. 


BEFORE: (Use LM weight = 4)
```
 | t h e | o l d h e r s | w h o | h u d | m a r e d | m a n d | h l d | n o t n c e | n | n t h e | l t l | o l | o n | p n c e | m a r y | h l | h u n r o u n d | h e r | b r o t h e r s | n e c e | b u t | s e n | t h e v | e | m p e r e | h o w | t h e | p l s r | h e o w | h n d | t o | r e t u r n | h e | h o l | h m a e |
```
AFTER: (Use LM weight = 4)
```

 | t h e | s o l d i e r s | w h o | h a d | c a r e d | f o r | a n d | h a d | n o t i c e d | a n d | t a k e n | t h e | t i t l e | g o l d | y o n | p r i n c e s | m a r y | h a d | h u n g | r o u n d | h e r | b r o t h e r ' s | n e c k | b u t | s e i n g | t h e | f a v o u r | t h e | e m p e r o r | s h o w e d | t h e | p r i s o n e r s | t h e y | n o w | h a s t e n e d | t o | r e t u r n | t h e | h o l y | i m a g e | |
```