### PR TITLE
[MMS] Fix concatenation of emissions

### DIFF
--- a/examples/mms/data_prep/align_and_segment.py
+++ b/examples/mms/data_prep/align_and_segment.py
@@ -51,12 +51,12 @@ def generate_emissions(model, audio_file):
             offset = time_to_frame(input_start_time)
 
             emissions_ = emissions_[
-                :, emission_start_frame - offset : emission_end_frame - offset
+                emission_start_frame - offset : emission_end_frame - offset, :
             ]
             emissions_arr.append(emissions_)
             i += EMISSION_INTERVAL
 
-    emissions = torch.cat(emissions_arr, dim=1).squeeze()
+    emissions = torch.cat(emissions_arr, dim=0).squeeze()
     emissions = torch.log_softmax(emissions, dim=-1)
 
     stride = float(waveform.size(1) * 1000 / emissions.size(0) / SAMPLING_FREQ)


### PR DESCRIPTION
1. Fix the dimension used to concatenate individual emissions for long audio file
2. Also fix a bug where context was being removed along label dimension (instead of time dimension)