### PR TITLE
Fix the MMS doc about LID manifest

### DIFF
--- a/examples/mms/README.md
+++ b/examples/mms/README.md
@@ -135,13 +135,13 @@ $ PYTHONPATH=$PYTHONPATH:/path/to/vits python examples/mms/tts/infer.py --model-
 ### LID
 
 
-Prepare two files in this format 
+Prepare two files in this format. Each manifest line contains <audio> and <number_of_sample>
 ```
 #/path/to/manifest.tsv
 /
-/path/to/audio1.wav
-/path/to/audio2.wav
-/path/to/audio3.wav
+/path/to/audio1.wav 180000
+/path/to/audio2.wav 240000
+/path/to/audio3.wav 160000
 
 # /path/to/manifest.lang
 eng 1

--- a/examples/mms/README.md
+++ b/examples/mms/README.md
@@ -139,9 +139,9 @@ Prepare two files in this format. Each manifest line contains <audio> and <numbe
 ```
 #/path/to/manifest.tsv
 /
-/path/to/audio1.wav 180000
-/path/to/audio2.wav 240000
-/path/to/audio3.wav 160000
+/path/to/audio1.wav	180000
+/path/to/audio2.wav	240000
+/path/to/audio3.wav	160000
 
 # /path/to/manifest.lang
 eng 1


### PR DESCRIPTION
# Before submitting

- [it's docs] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [y] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [y] Did you make sure to update the docs?
- [not appliable] Did you write any new necessary tests?

## What does this PR do?
The documentation for MMS regarding language identification has an incorrect format for the manifest. Following the current instructions, the code will give the following error:

```
  File "infer.py", line 153, in <module>
    infer_dataset = FileAudioDataset(infer_manifest, sample_rate=task.cfg.sample_rate, max_sample_size=10 ** 10, min_sample_size=1, pad=True, normalize=task.cfg.normalize)
  File "/home/kirill/anaconda3/envs/nganu/lib/python3.8/site-packages/fairseq/data/audio/raw_audio_dataset.py", line 274, in __init__
    assert len(items) == 2, line
AssertionError: sample_english_16.wav
```
Correct format is actually mentioned within the ASR section before the LID. This format has second column, indicating the number of samples in the audio file. The provided PR provides correct example in docs.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
