### PR TITLE
Register `weights` as a non-persistent buffer of `SinusoidalPositionalEmbedding`

### DIFF
--- a/fairseq/model_parallel/models/pipeline_parallel_transformer/model.py
+++ b/fairseq/model_parallel/models/pipeline_parallel_transformer/model.py
@@ -441,7 +441,6 @@ class PipelineParallelTransformerModel(BaseFairseqModel):
                 # fmt: off
                 if isinstance(module, TransformerEncoderEmbedding):
                     new_state_dict[f'model.partitions.{pid}.{mid}.embed_tokens.weight'] = state_dict['encoder.embed_tokens.weight']
-                    new_state_dict[f'model.partitions.{pid}.{mid}.embed_positions._float_tensor'] = state_dict['encoder.embed_positions._float_tensor']
                 if isinstance(module, TransformerEncoderLayer):
                     for suffix in encoder_key_suffixes:
                         new_state_dict[f'model.partitions.{pid}.{mid}.{suffix}'] = state_dict[f'encoder.layers.{encoder_layer_idx}.{suffix}']
@@ -456,7 +455,6 @@ class PipelineParallelTransformerModel(BaseFairseqModel):
                         new_state_dict[f'model.partitions.{pid}.{mid}.layer_norm.bias'] = state_dict['encoder.layer_norm.bias']
                 if isinstance(module, TransformerDecoderEmbedding):
                     new_state_dict[f'model.partitions.{pid}.{mid}.embed_tokens.weight'] = state_dict['decoder.embed_tokens.weight']
-                    new_state_dict[f'model.partitions.{pid}.{mid}.embed_positions._float_tensor'] = state_dict['decoder.embed_positions._float_tensor']
                 if isinstance(module, TransformerDecoderOutputLayer):
                     new_state_dict[f'model.partitions.{pid}.{mid}.output_projection.weight'] = state_dict['decoder.output_projection.weight']
                 # fmt: on
@@ -741,14 +739,6 @@ class TransformerDecoder(FairseqDecoder):
 
     def upgrade_state_dict_named(self, state_dict, name):
         """Upgrade a (possibly old) state dict for new versions of fairseq."""
-        if isinstance(self.embed_positions, SinusoidalPositionalEmbedding):
-            weights_key = "{}.embed_positions.weights".format(name)
-            if weights_key in state_dict:
-                del state_dict[weights_key]
-            state_dict[
-                "{}.embed_positions._float_tensor".format(name)
-            ] = torch.FloatTensor(1)
-
         for i in range(len(self.layers)):
             # update layer norms
             layer_norm_map = {

--- a/fairseq/models/masked_lm.py
+++ b/fairseq/models/masked_lm.py
@@ -294,12 +294,6 @@ class MaskedLMEncoder(FairseqEncoder):
         return self.max_positions
 
     def upgrade_state_dict_named(self, state_dict, name):
-        if isinstance(
-            self.sentence_encoder.embed_positions, SinusoidalPositionalEmbedding
-        ):
-            state_dict[
-                name + ".sentence_encoder.embed_positions._float_tensor"
-            ] = torch.FloatTensor(1)
         if not self.load_softmax:
             for k in list(state_dict.keys()):
                 if (

--- a/fairseq/models/transformer/transformer_decoder.py
+++ b/fairseq/models/transformer/transformer_decoder.py
@@ -399,14 +399,6 @@ class TransformerDecoderBase(FairseqIncrementalDecoder):
 
     def upgrade_state_dict_named(self, state_dict, name):
         """Upgrade a (possibly old) state dict for new versions of fairseq."""
-        if isinstance(self.embed_positions, SinusoidalPositionalEmbedding):
-            weights_key = "{}.embed_positions.weights".format(name)
-            if weights_key in state_dict:
-                del state_dict[weights_key]
-            state_dict[
-                "{}.embed_positions._float_tensor".format(name)
-            ] = torch.FloatTensor(1)
-
         if f"{name}.output_projection.weight" not in state_dict:
             if self.share_input_output_embed:
                 embed_out_key = f"{name}.embed_tokens.weight"

--- a/fairseq/models/transformer/transformer_decoder_aug.py
+++ b/fairseq/models/transformer/transformer_decoder_aug.py
@@ -305,14 +305,6 @@ class AugTransformerDecoderBase(TransformerDecoderBase):
 
     def upgrade_state_dict_named(self, state_dict, name):
         """Upgrade a (possibly old) state dict for new versions of fairseq."""
-        if isinstance(self.embed_positions, SinusoidalPositionalEmbedding):
-            weights_key = "{}.embed_positions.weights".format(name)
-            if weights_key in state_dict:
-                del state_dict[weights_key]
-            state_dict[
-                "{}.embed_positions._float_tensor".format(name)
-            ] = torch.FloatTensor(1)
-
         if f"{name}.output_projection.weight" not in state_dict:
             if self.share_input_output_embed:
                 embed_out_key = f"{name}.embed_tokens.weight"

--- a/fairseq/models/transformer/transformer_encoder.py
+++ b/fairseq/models/transformer/transformer_encoder.py
@@ -331,14 +331,6 @@ class TransformerEncoderBase(FairseqEncoder):
 
     def upgrade_state_dict_named(self, state_dict, name):
         """Upgrade a (possibly old) state dict for new versions of fairseq."""
-        if isinstance(self.embed_positions, SinusoidalPositionalEmbedding):
-            weights_key = "{}.embed_positions.weights".format(name)
-            if weights_key in state_dict:
-                print("deleting {0}".format(weights_key))
-                del state_dict[weights_key]
-            state_dict[
-                "{}.embed_positions._float_tensor".format(name)
-            ] = torch.FloatTensor(1)
         for i in range(self.num_layers):
             # update layer norms
             self.layers[i].upgrade_state_dict_named(

--- a/fairseq/modules/sinusoidal_positional_embedding.py
+++ b/fairseq/modules/sinusoidal_positional_embedding.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 import torch
 import torch.onnx.operators
 from fairseq import utils
-from torch import Tensor, nn
+from torch import nn, Tensor
 
 
 class SinusoidalPositionalEmbedding(nn.Module):
@@ -22,15 +22,22 @@ class SinusoidalPositionalEmbedding(nn.Module):
         super().__init__()
         self.embedding_dim = embedding_dim
         self.padding_idx = padding_idx if padding_idx is not None else 0
-        self.weights = SinusoidalPositionalEmbedding.get_embedding(
+        self.register_buffer("weights", SinusoidalPositionalEmbedding.get_embedding(
             init_size, embedding_dim, padding_idx
-        )
-        self.onnx_trace = False
-        self.register_buffer("_float_tensor", torch.FloatTensor(1))
+        ), persistent=False)
         self.max_positions = int(1e5)
+        self.onnx_trace = False
 
     def prepare_for_onnx_export_(self):
         self.onnx_trace = True
+
+    def _load_from_state_dict(self, state_dict, prefix, *args, **kwargs):
+        # Ignore some deprecated keys that were used in older versions
+        deprecated_keys = ["weights", "_float_tensor"]
+        for key in deprecated_keys:
+            if prefix + key in state_dict:
+                del state_dict[prefix + key]
+        super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
 
     @staticmethod
     def get_embedding(
@@ -68,12 +75,11 @@ class SinusoidalPositionalEmbedding(nn.Module):
         bspair = torch.onnx.operators.shape_as_tensor(input)
         bsz, seq_len = bspair[0], bspair[1]
         max_pos = self.padding_idx + 1 + seq_len
-        if self.weights is None or max_pos > self.weights.size(0):
-            # recompute/expand embeddings if needed
+        if max_pos > self.weights.size(0):
+            # expand embeddings if needed
             self.weights = SinusoidalPositionalEmbedding.get_embedding(
                 max_pos, self.embedding_dim, self.padding_idx
-            )
-        self.weights = self.weights.to(self._float_tensor)
+            ).to(self.weights)
 
         if incremental_state is not None:
             # positions is the same for every token when decoding a single step


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  Discussed this in a [GitHub issue](https://github.com/pytorch/pytorch/issues/75287#issuecomment-1602330466) of the pytorch repo.

- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?

- [ ] Did you make sure to update the docs?
  Not applicable

- [ ] Did you write any new necessary tests?
  No. But I've tested `deeplearning/projects/fairseq-py:test_cpu` in Meta's fbcode repo, and this diff does not introduce any new test failures.

## What does this PR do?

The module `SinusoidalPositionalEmbedding` has the problem that its `weights` attribute is not moved to CPU or CUDA when the module is moved.

Registering `weights` as a buffer solves the problem.
This also eliminates the need for the buffer `_float_tensor`, which is used to keep track of whether the module is on CPU or CUDA.

Making `weights` a non-persistent buffer means it won't be saved to or loaded from a `state_dict`.

With the changes in this diff, the `state_dict` of a `SinusoidalPositionalEmbedding` module should contain neither `weights` or `_float_tensor`.
This diff ignores them by overriding the `_load_from_state_dict` method of the `SinusoidalPositionalEmbedding` module, instead of duplicating the code in many `upgrade_state_dict` functions.

TO DISCUSS: Is it OK for me to override `_load_from_state_dict`? It's a private function, but I see people have overriden it in many places, including in fairseq:
https://github.com/search?q=super()._load_from_state_dict&type=code
https://github.com/search?q=repo%3Afacebookresearch%2Ffairseq%20super()._load_from_state_dict&type=code

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
