### PR TITLE
Fix mms torch audio log probs dimension error

### DIFF
--- a/examples/mms/data_prep/align_and_segment.py
+++ b/examples/mms/data_prep/align_and_segment.py
@@ -188,3 +188,4 @@ if __name__ == "__main__":
     print("Using device: ", DEVICE)
     args = parser.parse_args()
     main(args)
+    

--- a/examples/mms/data_prep/align_and_segment.py
+++ b/examples/mms/data_prep/align_and_segment.py
@@ -6,8 +6,8 @@ import json
 import argparse
 
 
-from examples.mms.data_prep.text_normalization import text_normalize
-from examples.mms.data_prep.align_utils import (
+from text_normalization import text_normalize
+from align_utils import (
     get_uroman_tokens,
     time_to_frame,
     load_model_dict,
@@ -87,13 +87,12 @@ def get_alignments(
     blank = dictionary["<blank>"]
     
     targets = torch.tensor(token_indices, dtype=torch.int32).to(DEVICE)
-    input_lengths = torch.tensor(emissions.shape[0])
-    target_lengths = torch.tensor(targets.shape[0])
-
+    input_lengths = torch.tensor(emissions.shape[0]).unsqueeze(-1)
+    target_lengths = torch.tensor(targets.shape[0]).unsqueeze(-1)
     path, _ = F.forced_align(
-        emissions, targets, input_lengths, target_lengths, blank=blank
+        emissions.unsqueeze(0), targets.unsqueeze(0), input_lengths, target_lengths, blank=blank
     )
-    path = path.to("cpu").tolist()
+    path = path.squeeze().to("cpu").tolist()
     segments = merge_repeats(path, {v: k for k, v in dictionary.items()})
     return segments, stride
 

--- a/examples/mms/data_prep/align_and_segment.py
+++ b/examples/mms/data_prep/align_and_segment.py
@@ -6,8 +6,8 @@ import json
 import argparse
 
 
-from text_normalization import text_normalize
-from align_utils import (
+from examples.mms.data_prep.text_normalization import text_normalize
+from examples.mms.data_prep.align_utils import (
     get_uroman_tokens,
     time_to_frame,
     load_model_dict,


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixing the issue #5248. The latest version of nightly torchaudio uses a 'log_probs' method expecting a tensor of 3 dimensions for the inputs and 2 dimensions for the targets. The 'input_lengths' and 'taget_lengths' need to have 2 dimensions too. The actual method 'get_alignments' of the file 'align_and_segment.py' creates tensors that don't have these expected dimensions. This pull request fixes this issue by unsqueezing the tensors in order to fit them to the expected dimensions for the 'log_probs' and 'forced_align' methods.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
