### PR TITLE
Makes Fairseq compatible with WandB when running in SageMaker so that experiments can be tracked

### DIFF
--- a/fairseq/logging/progress_bar.py
+++ b/fairseq/logging/progress_bar.py
@@ -513,7 +513,7 @@ class WandBProgressBarWrapper(BaseProgressBar):
 
     def update_config(self, config):
         """Log latest configuration."""
-        if wandb is not None and not self.is_running_in_sagemaker(self):
+        if wandb is not None and not self.is_running_in_sagemaker():
             wandb.config.update(config)
             print("updating wandb config")
             self.wrapped_bar.update_config(config)

--- a/fairseq/logging/progress_bar.py
+++ b/fairseq/logging/progress_bar.py
@@ -502,7 +502,7 @@ class WandBProgressBarWrapper(BaseProgressBar):
         self._log_to_wandb(stats, tag, step)
         self.wrapped_bar.log(stats, tag=tag, step=step)
     
-    def is_running_in_sagemaker():
+    def is_running_in_sagemaker(self):
         return 'SM_TRAINING_ENV' in os.environ
 
 
@@ -513,7 +513,7 @@ class WandBProgressBarWrapper(BaseProgressBar):
 
     def update_config(self, config):
         """Log latest configuration."""
-        if wandb is not None and not self.is_running_in_sagemaker():
+        if wandb is not None and not self.is_running_in_sagemaker(self):
             wandb.config.update(config)
             print("updating wandb config")
             self.wrapped_bar.update_config(config)

--- a/fairseq/logging/progress_bar.py
+++ b/fairseq/logging/progress_bar.py
@@ -503,7 +503,7 @@ class WandBProgressBarWrapper(BaseProgressBar):
         self.wrapped_bar.log(stats, tag=tag, step=step)
 
     def is_running_in_sagemaker(self):
-        return 'SM_TRAINING_ENV' in os.environ
+        return "SM_TRAINING_ENV" in os.environ
 
     def print(self, stats, tag=None, step=None):
         """Print end-of-epoch stats."""
@@ -516,7 +516,9 @@ class WandBProgressBarWrapper(BaseProgressBar):
             wandb.config.update(config)
             self.wrapped_bar.update_config(config)
         else:
-            print("Running in AWS SageMaker , Config updated from environment variables")
+            print(
+                "Running in AWS SageMaker , Config updated from environment variables"
+            )
 
     def _log_to_wandb(self, stats, tag=None, step=None):
         if wandb is None:

--- a/fairseq/logging/progress_bar.py
+++ b/fairseq/logging/progress_bar.py
@@ -501,6 +501,10 @@ class WandBProgressBarWrapper(BaseProgressBar):
         """Log intermediate stats to tensorboard."""
         self._log_to_wandb(stats, tag, step)
         self.wrapped_bar.log(stats, tag=tag, step=step)
+    
+    def is_running_in_sagemaker():
+        return 'SM_TRAINING_ENV' in os.environ
+
 
     def print(self, stats, tag=None, step=None):
         """Print end-of-epoch stats."""
@@ -509,9 +513,12 @@ class WandBProgressBarWrapper(BaseProgressBar):
 
     def update_config(self, config):
         """Log latest configuration."""
-        if wandb is not None:
-            #wandb.config.update(config)
-        self.wrapped_bar.update_config(config)
+        if wandb is not None and not self.is_running_in_sagemaker():
+            wandb.config.update(config)
+            print("updating wandb config")
+            self.wrapped_bar.update_config(config)
+        else:
+            print("running in sagemaker , skipping update wandb config")
 
     def _log_to_wandb(self, stats, tag=None, step=None):
         if wandb is None:

--- a/fairseq/logging/progress_bar.py
+++ b/fairseq/logging/progress_bar.py
@@ -501,10 +501,9 @@ class WandBProgressBarWrapper(BaseProgressBar):
         """Log intermediate stats to tensorboard."""
         self._log_to_wandb(stats, tag, step)
         self.wrapped_bar.log(stats, tag=tag, step=step)
-    
+
     def is_running_in_sagemaker(self):
         return 'SM_TRAINING_ENV' in os.environ
-
 
     def print(self, stats, tag=None, step=None):
         """Print end-of-epoch stats."""
@@ -515,10 +514,9 @@ class WandBProgressBarWrapper(BaseProgressBar):
         """Log latest configuration."""
         if wandb is not None and not self.is_running_in_sagemaker():
             wandb.config.update(config)
-            print("updating wandb config")
             self.wrapped_bar.update_config(config)
         else:
-            print("running in sagemaker , skipping update wandb config")
+            print("Running in AWS SageMaker , Config updated from environment variables")
 
     def _log_to_wandb(self, stats, tag=None, step=None):
         if wandb is None:

--- a/fairseq/logging/progress_bar.py
+++ b/fairseq/logging/progress_bar.py
@@ -510,7 +510,7 @@ class WandBProgressBarWrapper(BaseProgressBar):
     def update_config(self, config):
         """Log latest configuration."""
         if wandb is not None:
-            wandb.config.update(config)
+            #wandb.config.update(config)
         self.wrapped_bar.update_config(config)
 
     def _log_to_wandb(self, stats, tag=None, step=None):


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?


## What does this PR do?
Fixes # (#5313)
[Crashing in Sagmaker as a result of attempting to overwrite wandb config #5313](https://github.com/facebookresearch/fairseq/issues/5313)

adds check if fairseq is [being run in SM](https://github.com/fdsig/fairseq/blob/241128b906dd6d78a91f9a11df58a5ce00ce81de/fairseq/logging/progress_bar.py#L505) and then [calls check ](https://github.com/fdsig/fairseq/blob/241128b906dd6d78a91f9a11df58a5ce00ce81de/fairseq/logging/progress_bar.py#L515) and does not update config if running in SM

## PR review

cc @vklyukin 

## Did you have fun?

Always fun to dive into new code and help folks track experiments.

Make sure you had fun coding 🙃