### PR TITLE
fix overwrite bug when adding symbol to dictionary

### DIFF
--- a/fairseq/data/dictionary.py
+++ b/fairseq/data/dictionary.py
@@ -337,7 +337,7 @@ class Dictionary:
 
         for i, word in enumerate(words):
             if add_if_not_exist:
-                idx = self.add_symbol(word)
+                idx = self.add_symbol(word, overwrite=True)
             else:
                 idx = self.index(word)
             if consumer is not None:
@@ -367,7 +367,7 @@ class Dictionary:
     def add_file_to_dictionary(filename, dict, tokenize, num_workers):
         def merge_result(counter):
             for w, c in sorted(counter.items()):
-                dict.add_symbol(w, c)
+                dict.add_symbol(w, c, overwrite=True)
 
         local_file = PathManager.get_local_path(filename)
         offsets = find_offsets(local_file, num_workers)

--- a/fairseq/data/dictionary.py
+++ b/fairseq/data/dictionary.py
@@ -126,7 +126,7 @@ class Dictionary:
 
     def add_symbol(self, word, n=1, overwrite=False):
         """Adds a word to the dictionary"""
-        if word in self.indices and not overwrite:
+        if word in self.indices and overwrite:
             idx = self.indices[word]
             self.count[idx] = self.count[idx] + n
             return idx

--- a/fairseq/data/dictionary.py
+++ b/fairseq/data/dictionary.py
@@ -124,7 +124,7 @@ class Dictionary:
         else:
             return self.unk_word
 
-    def add_symbol(self, word, n=1, overwrite=False):
+    def add_symbol(self, word, n=1, overwrite=True):
         """Adds a word to the dictionary"""
         if word in self.indices and overwrite:
             idx = self.indices[word]
@@ -337,7 +337,7 @@ class Dictionary:
 
         for i, word in enumerate(words):
             if add_if_not_exist:
-                idx = self.add_symbol(word, overwrite=True)
+                idx = self.add_symbol(word)
             else:
                 idx = self.index(word)
             if consumer is not None:
@@ -367,7 +367,7 @@ class Dictionary:
     def add_file_to_dictionary(filename, dict, tokenize, num_workers):
         def merge_result(counter):
             for w, c in sorted(counter.items()):
-                dict.add_symbol(w, c, overwrite=True)
+                dict.add_symbol(w, c)
 
         local_file = PathManager.get_local_path(filename)
         offsets = find_offsets(local_file, num_workers)

--- a/fairseq/data/dictionary.py
+++ b/fairseq/data/dictionary.py
@@ -259,25 +259,25 @@ class Dictionary:
             try:
                 line, field = line.rstrip().rsplit(" ", 1)
                 if field == "#fairseq:overwrite":
-                    overwrite, duplicate = True, False
+                    overwrite = True
                     line, field = line.rsplit(" ", 1)
                 elif field == "#fairseq:duplicate":
-                    overwrite, duplicate = False, True
+                    overwrite = False
                     line, field = line.rsplit(" ", 1)
                 else:
-                    overwrite, duplicate = False, False
+                    if line in self:
+                        raise RuntimeError(
+                            "Duplicate word found when loading Dictionary: '{}'. "
+                            "Duplicate words can overwrite earlier ones by adding the "
+                            "#fairseq:overwrite flag at the end of the corresponding row "
+                            "in the dictionary file. Use the #fairseq:duplicate flag "
+                            "to keep duplicates in the dictionary (backward compatibility "
+                            "after bug fix). If using the Camembert model, please "
+                            "download an updated copy of the model file.".format(word)
+                        )
+                    overwrite = True # default behaviour
                 count = int(field)
                 word = line
-                if word in self and not overwrite and not duplicate:
-                    raise RuntimeError(
-                        "Duplicate word found when loading Dictionary: '{}'. "
-                        "Duplicate words can overwrite earlier ones by adding the "
-                        "#fairseq:overwrite flag at the end of the corresponding row "
-                        "in the dictionary file. Use the #fairseq:duplicate flag "
-                        "to keep duplicates in the dictionary (backward compatibility "
-                        "after bug fix). If using the Camembert model, please "
-                        "download an updated copy of the model file.".format(word)
-                    )
                 self.add_symbol(word, n=count, overwrite=overwrite)
             except ValueError:
                 raise ValueError(

--- a/fairseq/data/dictionary.py
+++ b/fairseq/data/dictionary.py
@@ -218,14 +218,17 @@ class Dictionary:
     def load(cls, f, add_special_symbols=True):
         """Loads the dictionary from a text file with the format:
 
-        ```
-        <symbol0> <count0> [<flag0>]
-        <symbol1> <count1> [<flag1>]
-        ...
-        ```
-        Possible flags are `#fairseq:overwrite` to overwrite duplicates 
-        and `#fairseq:duplicate` to keep them (for backwards compatibility 
-        after bug fix)
+        Example::
+            ```
+            <symbol0> <count0> [<flag0>]
+            <symbol1> <count1> [<flag1>]
+            ...
+            ```
+        
+        Note:
+            Possible flags are `#fairseq:overwrite` to overwrite duplicates 
+            and `#fairseq:duplicate` to keep them (for backward compatibility 
+            after bug fix)
         """
         d = cls(add_special_symbols=add_special_symbols)
         d.add_from_file(f)

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -122,7 +122,7 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual(d.index(","), 7)
         self.assertEqual(d.index("▁de"), 8)
 
-    def test_no_overwrite(self):
+    def test_no_overwrite_nor_duplicate(self):
         # for example, Camembert duplicates <unk>, <s> and </s>
         dict_file = io.StringIO(
             "<unk> 999\n" "<s> 999\n" "</s> 999\n" ", 999\n" "▁de 999\n"

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -90,11 +90,11 @@ class TestDictionary(unittest.TestCase):
         d.add_from_file(dict_file)
         self.assertEqual(d.index("<pad>"), 1)
         self.assertEqual(d.index("foo"), 3)
-        self.assertEqual(d.index("<unk>"), 4)
-        self.assertEqual(d.index("<s>"), 5)
-        self.assertEqual(d.index("</s>"), 6)
-        self.assertEqual(d.index(","), 7)
-        self.assertEqual(d.index("▁de"), 8)
+        self.assertEqual(d.index("<unk>"), 3)
+        self.assertEqual(d.index("<s>"), 0)
+        self.assertEqual(d.index("</s>"), 2)
+        self.assertEqual(d.index(","), 4)
+        self.assertEqual(d.index("▁de"), 5)
 
     def test_no_overwrite(self):
         # for example, Camembert overwrites <unk>, <s> and </s>

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -78,7 +78,6 @@ class TestDictionary(unittest.TestCase):
             assertMatch(finalized_ids, reload_ids)
 
     def test_overwrite(self):
-        # for example, Camembert overwrites <unk>, <s> and </s>
         dict_file = io.StringIO(
             "<unk> 999 #fairseq:overwrite\n"
             "<s> 999 #fairseq:overwrite\n"
@@ -88,6 +87,10 @@ class TestDictionary(unittest.TestCase):
         )
         d = Dictionary()
         d.add_from_file(dict_file)
+        self.assertEqual(d.bos(), 0)
+        self.assertEqual(d.pad(), 1)
+        self.assertEqual(d.eos(), 2)
+        self.assertEqual(d.unk(), 3)
         self.assertEqual(d.index("<pad>"), 1)
         self.assertEqual(d.index("foo"), 3)
         self.assertEqual(d.index("<unk>"), 3)
@@ -95,9 +98,32 @@ class TestDictionary(unittest.TestCase):
         self.assertEqual(d.index("</s>"), 2)
         self.assertEqual(d.index(","), 4)
         self.assertEqual(d.index("▁de"), 5)
+    
+    def test_duplicate(self):
+        # for example, Camembert duplicates <unk>, <s> and </s>
+        dict_file = io.StringIO(
+            "<unk> 999 #fairseq:duplicate\n"
+            "<s> 999 #fairseq:duplicate\n"
+            "</s> 999 #fairseq:duplicate\n"
+            ", 999\n"
+            "▁de 999\n"
+        )
+        d = Dictionary()
+        d.add_from_file(dict_file)
+        self.assertEqual(d.bos(), 0)
+        self.assertEqual(d.pad(), 1)
+        self.assertEqual(d.eos(), 2)
+        self.assertEqual(d.unk(), 3)
+        self.assertEqual(d.index("<pad>"), 1)
+        self.assertEqual(d.index("foo"), 3)
+        self.assertEqual(d.index("<unk>"), 4)
+        self.assertEqual(d.index("<s>"), 5)
+        self.assertEqual(d.index("</s>"), 6)
+        self.assertEqual(d.index(","), 7)
+        self.assertEqual(d.index("▁de"), 8)
 
     def test_no_overwrite(self):
-        # for example, Camembert overwrites <unk>, <s> and </s>
+        # for example, Camembert duplicates <unk>, <s> and </s>
         dict_file = io.StringIO(
             "<unk> 999\n" "<s> 999\n" "</s> 999\n" ", 999\n" "▁de 999\n"
         )


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes #3064.
Fixes #3705.
Fixes #1309.

TLDR; **This PR fixes the bug that duplicates the symbols that were meant to be overwritten in the vocabulary file.** See detailed explanation in this [blog post](https://lydianishimwe.info/blog/fairseq-overwrite/).

### Expected behavior:

A Dictionary object has an `indices` dict and two lists (`symbols` and `counts`). By default, when loading a vocabulary from a file, a Dictionary instance is first created by adding 4 special tokens (`<s>`,  `<pad>`, `</s>` and `<unk>` in that order). Then, all the entries from the file are appended to the Dictionary. If the vocabulary file already has some of the special tokens, their file entry should contain `#fairseq:overwrite`, otherwise a "duplicate" error will be raised at runtime. Furthermore, during preprocessing, the saved dictionary should not contain any of the special symbols. 

### Current behavior: 

The `add_symbol` function is responsible for adding the symbols to the Dictionary. It has an `overwrite` argument that is set to `True` when the corresponding line in the file has `#fairseq:overwrite`.  Rather than testing `if word in self.indices and overwrite`, it is currently testing `if word in self.indices and not overwrite`, which makes it ignore the case where the symbol should actually be overwritten. Hence, the symbol is appended to the `symbols` list, and its index is changed in the `indices` dict. This results in duplicate symbols and incorrect indices. Generally, only the special symbols will be affected. However, because the number of special tokens is set during initialization, it remains correct.

For example, a dictionary with 50K tokens that already has `<s>`, `<pad>` , `</s>` and `<unk>` with the `#fairseq:overwrite` tag will end up having 50004 tokens when loaded. This will also propagate to the subsequent model which will have an embedding dimension of 50004 instead of 50K. Also, with `fairseq-preprocess`, the resulting dictionary will skip the first 4 special symbols but will still contain the duplicate ones.

### Domino effects and backward compatibility: 

By fixing this bug, dictionary files will be loaded properly. However, this fix might cause problems in pipelines that use existing architectures and pretrained models because of the mismatch in sentencepiece encoding and/or embedding dimension.

For the sake of backward compatibility, a `#fairseq:duplicate` flag is introduced to ensure that duplicates are kept in the dictionary just like the bug. When used with `fairseq-preprocess`, the produced dict.txt file will also write `#fairseq:duplicate` next to the same symbols.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Yes, I did 🙃
