### PR TITLE
Keep task level checkpoint key name generic

### DIFF
--- a/fairseq/checkpoint_utils.py
+++ b/fairseq/checkpoint_utils.py
@@ -116,7 +116,7 @@ def save_checkpoint(cfg: CheckpointConfig, trainer, epoch_itr, val_loss):
     # attributes
     if hasattr(trainer.task, "get_checkpoint_dict"):
         extra_state = {**extra_state, **trainer.task.get_checkpoint_dict()}
-        logger.info(f"{trainer.task.__class__} checkpoint worthy attributes are ready to be persisted with the checkpoint")
+        logger.info(f"State of {trainer.task.__class__.__name__} is ready to be persisted with the checkpoint")
 
     if hasattr(save_checkpoint, "best"):
         extra_state.update({"best": save_checkpoint.best})
@@ -289,10 +289,10 @@ def load_checkpoint(cfg: CheckpointConfig, trainer, **passthrough_args):
         )
         epoch_itr.load_state_dict(itr_state)
 
-        # Preload the observer stats for Supernet
-        supernet_cp_dict = extra_state.get("supernet", {})
-        if supernet_cp_dict and hasattr(trainer.task, "set_checkpoint_dict"):
-            trainer.task.set_checkpoint_dict(supernet_cp_dict)
+        # Preload the checkpoint for the task
+        task_cp_dict = extra_state.get(trainer.task.__class__.__name__, {})
+        if task_cp_dict and hasattr(trainer.task, "set_checkpoint_dict"):
+            trainer.task.set_checkpoint_dict(task_cp_dict)
     else:
         epoch_itr = trainer.get_train_iterator(
             epoch=1, load_dataset=True, **passthrough_args

--- a/tests/test_checkpoint_utils_for_task_level_attributes.py
+++ b/tests/test_checkpoint_utils_for_task_level_attributes.py
@@ -20,9 +20,10 @@ def mock_trainer(epoch, num_updates, iterations_in_epoch):
             "iterations_in_epoch": iterations_in_epoch,
             "shuffle": False,
         },
-        "task_name": checkpoint_dict()["task_name"],
+        "FakeTask": checkpoint_dict()["FakeTask"],
     }
     trainer.get_num_updates.return_value = num_updates
+    trainer.task.__class__.__name__ = "FakeTask"
     trainer.task.get_checkpoint_dict.return_value = checkpoint_dict()
     trainer.task.set_checkpoint_dict = MagicMock()
 
@@ -31,7 +32,7 @@ def mock_trainer(epoch, num_updates, iterations_in_epoch):
 
 def checkpoint_dict():
     return {
-        "task_name": {
+        "FakeTask": {
             "observer_stats": {
                 (
                     4,
@@ -131,9 +132,9 @@ class TestCheckpointsForTaskLevelAttributes(unittest.TestCase):
     def test_verify_checkpoint(self) -> None:
         cp_dict = self.trainer.task.get_checkpoint_dict()
         self.assertTrue(len(cp_dict) == 1)
-        self.assertTrue("task_name" in cp_dict)
-        self.assertTrue("observer_stats" in cp_dict["task_name"])
-        self.assertTrue(len(cp_dict["task_name"]["observer_stats"]) == 1)
+        self.assertTrue("FakeTask" in cp_dict)
+        self.assertTrue("observer_stats" in cp_dict["FakeTask"])
+        self.assertTrue(len(cp_dict["FakeTask"]["observer_stats"]) == 1)
         self.assertTrue(
             (
                 4,
@@ -141,10 +142,10 @@ class TestCheckpointsForTaskLevelAttributes(unittest.TestCase):
                 "MovingAveragePerChannelMinMax",
                 "MovingAveragePerChannelMinMax",
             )
-            in cp_dict["task_name"]["observer_stats"]
+            in cp_dict["FakeTask"]["observer_stats"]
         )
         self.assertTrue(
-            cp_dict["task_name"]["observer_stats"][
+            cp_dict["FakeTask"]["observer_stats"][
                 (
                     4,
                     16,
@@ -163,7 +164,7 @@ class TestCheckpointsForTaskLevelAttributes(unittest.TestCase):
             )
 
             self.trainer.task.set_checkpoint_dict.assert_called_once_with(
-                checkpoint_dict()["task_name"]
+                checkpoint_dict()["FakeTask"]
             )
 
 

--- a/tests/test_checkpoint_utils_for_task_level_attributes.py
+++ b/tests/test_checkpoint_utils_for_task_level_attributes.py
@@ -20,7 +20,7 @@ def mock_trainer(epoch, num_updates, iterations_in_epoch):
             "iterations_in_epoch": iterations_in_epoch,
             "shuffle": False,
         },
-        "supernet": checkpoint_dict()["supernet"],
+        "task_name": checkpoint_dict()["task_name"],
     }
     trainer.get_num_updates.return_value = num_updates
     trainer.task.get_checkpoint_dict.return_value = checkpoint_dict()
@@ -31,7 +31,7 @@ def mock_trainer(epoch, num_updates, iterations_in_epoch):
 
 def checkpoint_dict():
     return {
-        "supernet": {
+        "task_name": {
             "observer_stats": {
                 (
                     4,
@@ -131,9 +131,9 @@ class TestCheckpointsForTaskLevelAttributes(unittest.TestCase):
     def test_verify_checkpoint(self) -> None:
         cp_dict = self.trainer.task.get_checkpoint_dict()
         self.assertTrue(len(cp_dict) == 1)
-        self.assertTrue("supernet" in cp_dict)
-        self.assertTrue("observer_stats" in cp_dict["supernet"])
-        self.assertTrue(len(cp_dict["supernet"]["observer_stats"]) == 1)
+        self.assertTrue("task_name" in cp_dict)
+        self.assertTrue("observer_stats" in cp_dict["task_name"])
+        self.assertTrue(len(cp_dict["task_name"]["observer_stats"]) == 1)
         self.assertTrue(
             (
                 4,
@@ -141,10 +141,10 @@ class TestCheckpointsForTaskLevelAttributes(unittest.TestCase):
                 "MovingAveragePerChannelMinMax",
                 "MovingAveragePerChannelMinMax",
             )
-            in cp_dict["supernet"]["observer_stats"]
+            in cp_dict["task_name"]["observer_stats"]
         )
         self.assertTrue(
-            cp_dict["supernet"]["observer_stats"][
+            cp_dict["task_name"]["observer_stats"][
                 (
                     4,
                     16,
@@ -163,10 +163,9 @@ class TestCheckpointsForTaskLevelAttributes(unittest.TestCase):
             )
 
             self.trainer.task.set_checkpoint_dict.assert_called_once_with(
-                checkpoint_dict()["supernet"]
+                checkpoint_dict()["task_name"]
             )
 
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
In #5328, we introduced the logic of saving task level checkpoints. However, the task name was naively set to `supernet`. This PR fixes this issue by leveraging task's class name instead.

## PR review
@cbalioglu 

## Did you have fun?
Make sure you had fun coding 🙃
