### PR TITLE
fix iterator when loading from checkpoint

### DIFF
--- a/fairseq/data/iterators.py
+++ b/fairseq/data/iterators.py
@@ -524,7 +524,7 @@ class EpochBatchIterator(EpochBatchIterating):
             # TODO: Below is a lazy implementation which discard the final batch regardless
             # of whether it is a full batch or not.
 
-            total_num_itrs = len(self.epoch_batch_sampler) - 1
+            total_num_itrs = len(itr) - 1
             itr.take(total_num_itrs)
             logger.info(f"skip final residual batch, total_num_itrs = {total_num_itrs}")
 


### PR DESCRIPTION
# Before submitting

- [no] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [yes] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [yes] Did you make sure to update the docs?
- [yes] Did you write any new necessary tests?

## What does this PR do?
Assuming an epoch consist of N batches. When we load a checkpoint from mid epoch, there is a number indicate the number of iterations n has been passed in the epoch. When restarting the training job, after the batches are loaded, n batches are removed from the beginning of the iterator by FrozenBatchSampler. Then the CounteringIterator would add n iteration count in front of the batch, so that the batch count in the epoch is correct, i.e. N-n+n = N.
However, when skip_reminder_batch is set to True, the CounteringIterator would truncate, incorrectly, the batch count from N batches to N-n, causing the epoch to have less number of total batches. As a result, you would see a jump in the fblearner ui on the progress --- not because the iteration counter increase, but rather because the total number of batches decrease.
This diffs would fix the problem above.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
