### PR TITLE
Update base_audio_only_task.yaml

### DIFF
--- a/examples/data2vec/config/v2/base_audio_only_task.yaml
+++ b/examples/data2vec/config/v2/base_audio_only_task.yaml
@@ -66,7 +66,7 @@ model:
   loss_beta: 0
   loss_scale: null
 
-  depth: 12
+  depth: 8
   embed_dim: 768
   clone_batch: 8
 
@@ -91,7 +91,7 @@ model:
       conv_pos_depth: 5
       conv_pos_width: 95
       conv_pos_groups: 16
-      prenet_depth: 0
+      prenet_depth: 4
       mask_prob: 0.5
       mask_prob_adjust: 0.05
       inverse_mask: false


### PR DESCRIPTION
## What does this PR do?
There is a mismatch between the audio config and the audio checkpoint. Change the `base_audio_only_task.yaml` file from depth=12, prenet_depth=0 to depth=8, prenet_depth=4 will not affect the training but fix the bug for loading the audio checkpoint.
