### PR TITLE
Changed metrics import location on speech_dlm_criterion

### DIFF
--- a/fairseq/criterions/speech_dlm_criterion.py
+++ b/fairseq/criterions/speech_dlm_criterion.py
@@ -8,7 +8,8 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import torch.nn.functional as F
-from fairseq import metrics, utils
+from fairseq import utils
+from fairseq.logging import metrics
 from fairseq.criterions import FairseqCriterion, register_criterion
 from fairseq.dataclass import FairseqDataclass
 from omegaconf import II


### PR DESCRIPTION
Fixes issue #5366.
Fixes deprecated `from fairseq import metrics` changing the import with the new location `from fairseq.logging import metrics` on the `speech_dlm_criterion` used in the `fairseq-train` run on the [SimpleLSTM tutorial](https://fairseq.readthedocs.io/en/latest/tutorial_simple_lstm.html).
