### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,9 @@ jobs:
           new_tag=$(echo $output | awk '{print $2}')
           echo "new version is $new_version"
           echo "new tag is $new_tag"
-          echo ::set-output name=version::$new_version
-          echo ::set-output name=tag::$new_tag
-          echo ::set-output name=branch_name::$new_version-release
+          echo "version=$new_version" >> $GITHUB_OUTPUT
+          echo "tag=$new_tag" >> $GITHUB_OUTPUT
+          echo "branch_name=$new_version-release" >> $GITHUB_OUTPUT
           echo "NEW_TAG=$new_tag" >> $GITHUB_ENV
           echo "NEW_BRANCH=$new_version-release" >> $GITHUB_ENV
 


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter