### PR TITLE
README.glue.md GLUE Preprocess script is incorrect.

### DIFF
--- a/examples/roberta/README.glue.md
+++ b/examples/roberta/README.glue.md
@@ -19,7 +19,7 @@ Example fine-tuning cmd for `RTE` task
 ```bash
 ROBERTA_PATH=/path/to/roberta/model.pt
 
-CUDA_VISIBLE_DEVICES=0 fairseq-hydra-train -config-dir examples/roberta/config/finetuning --config-name rte \
+CUDA_VISIBLE_DEVICES=0 fairseq-hydra-train --config-dir examples/roberta/config/finetuning --config-name rte \
 task.data=RTE-bin checkpoint.restore_file=$ROBERTA_PATH
 ```
 


### PR DESCRIPTION
## What does this PR do?
The script for running fairseq-hydra-train is incorrect and uses the invalid flag -config-dir. Fixed it to the correct flag --config-dir.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Yes.
