### PR TITLE
fix: upper bound torch audio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,7 @@ def do_setup(package_data):
             "numpy>=1.21.3",
             "regex",
             "sacrebleu>=1.4.12",
-            "torch>=1.13",
+            "torch==1.13.1",
             "tqdm",
             "bitarray",
             "torchaudio>=0.8.0",

--- a/setup.py
+++ b/setup.py
@@ -179,8 +179,8 @@ def do_setup(package_data):
         install_requires=[
             "cffi",
             "cython",
-            "hydra-core>=1.0.7,<1.1",
-            "omegaconf<2.1",
+            "hydra-core>=1.3.2,<2.0",
+            "omegaconf>=2.2,<2.4",
             "numpy>=1.21.3",
             "regex",
             "sacrebleu>=1.4.12",

--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ def do_setup(package_data):
             "torch==1.13.1",
             "tqdm",
             "bitarray",
-            "torchaudio>=0.8.0",
+            "torchaudio>=0.8.0, <2.2.2",
             "scikit-learn",
             "packaging",
         ],


### PR DESCRIPTION
The [latest pytorch release](https://github.com/pytorch/pytorch/releases/tag/v2.2.2) (2.2.2) requires gcc 9 or higher. This impacts torchaudio, and broke our build. This PR adds an upper bound on the torchaudio version so this doesn't break.