### PR TITLE
Pt2.6 compatibility

### DIFF
--- a/fairseq/checkpoint_utils.py
+++ b/fairseq/checkpoint_utils.py
@@ -337,7 +337,7 @@ def load_checkpoint_to_cpu(path, arg_overrides=None, load_on_all_ranks=False):
         local_path = PathManager.get_local_path(path)
 
     with open(local_path, "rb") as f:
-        state = torch.load(f, map_location=torch.device("cpu"))
+        state = torch.load(f, map_location=torch.device("cpu"), wights_only=False)
 
     if "args" in state and state["args"] is not None and arg_overrides is not None:
         args = state["args"]
@@ -911,6 +911,7 @@ def load_ema_from_checkpoint(fpath):
             map_location=(
                 lambda s, _: torch.serialization.default_restore_location(s, "cpu")
             ),
+            weights_only=False,
         )
 
         # EMA model is stored in a separate "extra state"

--- a/fairseq/checkpoint_utils.py
+++ b/fairseq/checkpoint_utils.py
@@ -337,7 +337,7 @@ def load_checkpoint_to_cpu(path, arg_overrides=None, load_on_all_ranks=False):
         local_path = PathManager.get_local_path(path)
 
     with open(local_path, "rb") as f:
-        state = torch.load(f, map_location=torch.device("cpu"), wights_only=False)
+        state = torch.load(f, map_location=torch.device("cpu"), weights_only=False)
 
     if "args" in state and state["args"] is not None and arg_overrides is not None:
         args = state["args"]


### PR DESCRIPTION
# Before submitting

- [x ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)

- [ x] Did you read the [contributor guideline](https://github.com/pytorch/fairseq/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs? (no need)
- [ ] Did you write any new necessary tests? (no need)

## What does this PR do?
Fixes #5610.

The default value for the weights_only argument in torch.load() changed from False to True between PyTorch versions 2.5 and 2.6. By explicitly including weights_only=False in the torch.load calls, the code is kept working in the same way as previously also in PyTorch >= 2.6.
