### PR TITLE
Update data_cfg.py

### DIFF
--- a/fairseq/data/audio/data_cfg.py
+++ b/fairseq/data/audio/data_cfg.py
@@ -118,6 +118,7 @@ class S2TDataConfig(object):
         raw audio as inputs."""
         return self.config.get("use_audio_input", False)
 
+    @property
     def standardize_audio(self) -> bool:
         return self.use_audio_input and self.config.get("standardize_audio", False)
 


### PR DESCRIPTION
add @property to def standardize_audio(self) -> bool

## What does this PR do?
Here is a bug with the function.
when we call `self.cfg.standardize_audio`, it always return true. 
see https://github.com/facebookresearch/fairseq/blob/main/fairseq/data/audio/speech_to_text_dataset.py#L244-L248
```
if self.cfg.use_audio_input:
    source = torch.from_numpy(source).float()
    if self.cfg.standardize_audio:
        with torch.no_grad():
            source = F.layer_norm(source, source.shape)
```

I think the function need a `@property`.
