### PR TITLE
Fix NumPy 1.24+ compatibility: replace deprecated np.float

### DIFF
--- a/examples/data2vec/models/mae.py
+++ b/examples/data2vec/models/mae.py
@@ -403,7 +403,7 @@ def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
     out: (M, D)
     """
     assert embed_dim % 2 == 0
-    omega = np.arange(embed_dim // 2, dtype=np.float)
+    omega = np.arange(embed_dim // 2, dtype=np.float64)
     omega /= embed_dim / 2.0
     omega = 1.0 / 10000 ** omega  # (D/2,)
 

--- a/fairseq/modules/dynamic_crf_layer.py
+++ b/fairseq/modules/dynamic_crf_layer.py
@@ -105,7 +105,7 @@ class DynamicCRF(nn.Module):
         beam = beam if beam is not None else self.beam
         batch_size, seq_len = emissions.size()[:2]
         if targets is not None:
-            _emissions = emissions.scatter(2, targets[:, :, None], np.float("inf"))
+            _emissions = emissions.scatter(2, targets[:, :, None], float("inf"))
             beam_targets = _emissions.topk(beam, 2)[1]
             beam_emission_scores = emissions.gather(2, beam_targets)
         else:


### PR DESCRIPTION
## Summary
- Replace deprecated NumPy float aliases to support NumPy 1.24+

## Changes
- `fairseq/modules/dynamic_crf_layer.py`: Replace `np.float("inf")` with `float("inf")`
- `examples/data2vec/models/mae.py`: Replace `np.float` with `np.float64`

## Background
`np.float` was deprecated in NumPy 1.20 and removed in NumPy 1.24. Using `np.float` now raises `AttributeError: module 'numpy' has no attribute 'float'`.

## Test plan
- [x] Verified the fix maintains the same behavior
- [x] `float("inf")` is the correct way to represent infinity
- [x] `np.float64` maintains the same precision as the original `np.float`

Fixes #4945

🤖 Generated with [Claude Code](https://claude.com/claude-code)