### PR TITLE
fix: replace 40 bare except clauses with except Exception

### DIFF
--- a/examples/adaptive_span/truncated_bptt_lm_task.py
+++ b/examples/adaptive_span/truncated_bptt_lm_task.py
@@ -1,1 +1,285 @@
-../truncated_bptt/truncated_bptt_lm_task.py
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+import torch
+from fairseq import utils
+from fairseq.data import (
+    Dictionary,
+    TokenBlockDataset,
+    data_utils,
+    iterators,
+)
+from fairseq.dataclass import FairseqDataclass
+from fairseq.distributed import utils as dist_utils
+from fairseq.tasks import FairseqTask, register_task
+from omegaconf import II
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TruncatedBPTTLMConfig(FairseqDataclass):
+    data: str = field(default="???", metadata={"help": "path to data directory"})
+    tokens_per_sample: int = field(
+        default=1024, metadata={"help": "max number of tokens per sequence"},
+    )
+    batch_size: int = II("dataset.batch_size")
+    # Some models use *max_target_positions* to know how many positional
+    # embeddings to learn. We use II(...) to make it default to
+    # *tokens_per_sample*, but in principle there could be more positional
+    # embeddings than tokens in a single batch. This may also be irrelevant for
+    # custom model implementations.
+    max_target_positions: int = II("task.tokens_per_sample")
+    # these will be populated automatically if not provided
+    data_parallel_rank: Optional[int] = None
+    data_parallel_size: Optional[int] = None
+
+
+@register_task("truncated_bptt_lm", dataclass=TruncatedBPTTLMConfig)
+class TruncatedBPTTLMTask(FairseqTask):
+    def __init__(self, cfg: TruncatedBPTTLMConfig):
+        super().__init__(cfg)
+
+        if cfg.data_parallel_rank is None or cfg.data_parallel_size is None:
+            if torch.distributed.is_initialized():
+                cfg.data_parallel_rank = dist_utils.get_data_parallel_rank()
+                cfg.data_parallel_size = dist_utils.get_data_parallel_world_size()
+            else:
+                cfg.data_parallel_rank = 0
+                cfg.data_parallel_size = 1
+
+        # load the dictionary
+        paths = utils.split_paths(cfg.data)
+        assert len(paths) > 0
+        self.dictionary = Dictionary.load(os.path.join(paths[0], "dict.txt"))
+        logger.info("dictionary: {} types".format(len(self.dictionary)))
+
+    def load_dataset(self, split, epoch=1, combine=False, **kwargs):
+        """Load a given dataset split (e.g., train, valid, test)"""
+
+        # support sharded datasets
+        paths = utils.split_paths(self.cfg.data)
+        assert len(paths) > 0
+        data_path = paths[(epoch - 1) % len(paths)]
+        split_path = os.path.join(data_path, split)
+
+        # each element of *data* will be a tensorized line from the original
+        # text dataset, similar to ``open(split_path).readlines()``
+        data = data_utils.load_indexed_dataset(
+            split_path, self.dictionary, combine=combine
+        )
+        if data is None:
+            raise FileNotFoundError(
+                "Dataset not found: {} ({})".format(split, split_path)
+            )
+
+        # this is similar to ``data.view(-1).split(tokens_per_sample)``
+        data = TokenBlockDataset(
+            data,
+            data.sizes,
+            block_size=self.cfg.tokens_per_sample,
+            pad=None,  # unused
+            eos=None,  # unused
+            break_mode="none",
+        )
+
+        self.datasets[split] = TruncatedBPTTDataset(
+            data=data,
+            bsz_per_shard=self.cfg.batch_size,
+            shard_id=self.cfg.data_parallel_rank,
+            num_shards=self.cfg.data_parallel_size,
+        )
+
+    def dataset(self, split):
+        return self.datasets[split]
+
+    def get_batch_iterator(
+        self,
+        dataset,
+        num_workers=0,
+        epoch=1,
+        data_buffer_size=0,
+        skip_remainder_batch=False,
+        **kwargs
+    ):
+        return iterators.EpochBatchIterator(
+            dataset=dataset,
+            collate_fn=self._collate_fn,
+            num_workers=num_workers,
+            epoch=epoch,
+            buffer_size=data_buffer_size,
+            # we don't use the batching functionality from EpochBatchIterator;
+            # instead every item in *dataset* is a whole batch
+            batch_sampler=[[i] for i in range(len(dataset))],
+            disable_shuffling=True,
+            skip_remainder_batch=skip_remainder_batch,
+        )
+
+    def _collate_fn(self, items: List[List[torch.Tensor]]):
+        # we don't use fairseq's batching functionality, so we expect a single
+        # Tensor of type List[torch.Tensor]
+        assert len(items) == 1
+
+        # item will have shape B x T (the last batch may have length < T)
+        id, item = items[0]
+        item = data_utils.collate_tokens(item, pad_idx=self.source_dictionary.pad())
+        B, T = item.size()
+
+        # shift item one position over and append a padding token for the target
+        target = torch.nn.functional.pad(
+            item[:, 1:], (0, 1, 0, 0), value=self.target_dictionary.pad()
+        )
+
+        # fairseq expects batches to have the following structure
+        return {
+            "id": torch.tensor([id] * item.size(0)),
+            "net_input": {"src_tokens": item,},
+            "target": target,
+            "nsentences": item.size(0),
+            "ntokens": item.numel(),
+        }
+
+    def build_dataset_for_inference(
+        self, src_tokens: List[torch.Tensor], src_lengths: List[int], **kwargs
+    ) -> torch.utils.data.Dataset:
+        eos = self.source_dictionary.eos()
+        dataset = TokenBlockDataset(
+            src_tokens,
+            src_lengths,
+            block_size=None,  # ignored for "eos" break mode
+            pad=self.source_dictionary.pad(),
+            eos=eos,
+            break_mode="eos",
+        )
+
+        class Dataset(torch.utils.data.Dataset):
+            def __getitem__(self, i):
+                item = dataset[i]
+                if item[-1] == eos:
+                    # remove eos to support generating with a prefix
+                    item = item[:-1]
+                return (i, [item])
+
+            def __len__(self):
+                return len(dataset)
+
+        return Dataset()
+
+    def inference_step(
+        self, generator, models, sample, prefix_tokens=None, constraints=None
+    ):
+        with torch.no_grad():
+            if constraints is not None:
+                raise NotImplementedError
+
+            # SequenceGenerator doesn't use *src_tokens* directly, we need to
+            # pass the *prefix_tokens* argument instead.
+            if prefix_tokens is None and sample["net_input"]["src_tokens"].nelement():
+                prefix_tokens = sample["net_input"]["src_tokens"]
+
+            # begin generation with the end-of-sentence token
+            bos_token = self.source_dictionary.eos()
+
+            return generator.generate(
+                models, sample, prefix_tokens=prefix_tokens, bos_token=bos_token
+            )
+
+    def eval_lm_dataloader(
+        self,
+        dataset,
+        max_tokens: Optional[int] = 36000,
+        batch_size: Optional[int] = None,
+        max_positions: Optional[int] = None,
+        num_shards: int = 1,
+        shard_id: int = 0,
+        num_workers: int = 1,
+        data_buffer_size: int = 10,
+        context_window: int = 0,
+    ):
+        if context_window > 0:
+            raise NotImplementedError(
+                "Transformer-XL doesn't need --context-window, try "
+                "--model-overrides '{\"mem_len\":42}' instead "
+            )
+        return self.get_batch_iterator(
+            dataset=dataset,
+            max_tokens=max_tokens,
+            max_sentences=batch_size,
+            max_positions=max_positions,
+            ignore_invalid_inputs=True,
+            num_shards=num_shards,
+            shard_id=shard_id,
+            num_workers=num_workers,
+            data_buffer_size=data_buffer_size,
+        ).next_epoch_itr(shuffle=False)
+
+    @property
+    def source_dictionary(self):
+        return self.dictionary
+
+    @property
+    def target_dictionary(self):
+        return self.dictionary
+
+
+class TruncatedBPTTDataset(torch.utils.data.Dataset):
+    def __init__(
+        self,
+        data: List[torch.Tensor],  # ordered list of items
+        bsz_per_shard,  # number of items processed per GPUs per forward
+        shard_id,  # current GPU ID
+        num_shards,  # number of GPUs
+    ):
+        super().__init__()
+        self.data = data
+
+        def batchify(data, bsz):
+            # Work out how cleanly we can divide the dataset into bsz parts.
+            nbatch = data.size(0) // bsz
+            # Trim off any extra elements that wouldn't cleanly fit (remainders).
+            data = data.narrow(0, 0, nbatch * bsz)
+            # Evenly divide the data across the bsz batches.
+            data = data.view(bsz, -1).contiguous()
+            return data
+
+        # total number of sequences processed by all GPUs in each forward pass
+        global_batch_size = bsz_per_shard * num_shards
+
+        """
+        With a 16 item dataset, bsz_per_shard=2 and num_shards=3,
+        *indices* might look like:
+
+            indices = [[0, 1],
+                       [2, 3],
+                       [4, 5],
+                       [6, 7],
+                       [8, 9],
+                       [10, 11]]
+
+        The size of the TruncatedBPTTDataset instance will be 2,
+        and shard 1 will see items:
+
+            [(0, [data[4], data[6]]),
+             (1, [data[5], data[7]])]
+        """
+        indices = batchify(torch.arange(len(data)), global_batch_size)
+        assert indices.size(0) == global_batch_size
+
+        self.my_indices = indices[
+            shard_id * bsz_per_shard : (shard_id + 1) * bsz_per_shard
+        ]
+        assert self.my_indices.size(0) == bsz_per_shard
+
+    def __len__(self):
+        return self.my_indices.size(1)
+
+    def __getitem__(self, i) -> Tuple[int, List[torch.Tensor]]:
+        return (i, [self.data[idx] for idx in self.my_indices[:, i]])

--- a/examples/data2vec/models/data2vec2.py
+++ b/examples/data2vec/models/data2vec2.py
@@ -275,7 +275,7 @@ class Data2VecMultiModel(BaseFairseqModel):
             from apex.normalization import FusedLayerNorm
 
             fn = FusedLayerNorm
-        except:
+        except Exception:
             fn = nn.LayerNorm
 
         if isinstance(m, nn.Linear):

--- a/examples/data2vec/models/mae.py
+++ b/examples/data2vec/models/mae.py
@@ -23,7 +23,7 @@ from fairseq.models.wav2vec.wav2vec2 import TransformerSentenceEncoderLayer
 
 try:
     from apex.normalization import FusedLayerNorm
-except:
+except Exception:
     FusedLayerNorm = nn.LayerNorm
 
 import torch.nn.functional as F

--- a/examples/data2vec/scripts/text/glue.py
+++ b/examples/data2vec/scripts/text/glue.py
@@ -29,6 +29,6 @@ for run, tasks in grouped.items():
     avg_norte = sum(float(v) for k,v in tasks.items() if k != 'rte') / (len(tasks) -1)
     try:
         print(f"{tasks['cola']}\t{tasks['qnli']}\t{tasks['mrpc']}\t{tasks['rte']}\t{tasks['sst_2']}\t{avg:.2f}\t{avg_norte:.2f}")
-    except:
+    except Exception:
         print(tasks)
     print()

--- a/examples/data2vec/scripts/text/valids.py
+++ b/examples/data2vec/scripts/text/valids.py
@@ -39,7 +39,7 @@ def main(args, print_output):
     def extract_metric(s, metric):
         try:
             j = json.loads(s)
-        except:
+        except Exception:
             return None
         if args.epoch is not None and ('epoch' not in j or j['epoch'] != args.epoch):
             return None
@@ -113,13 +113,13 @@ def main(args, print_output):
                         idx = line.index("{")
                         line = line[idx:]
                         line_json = json.loads(line)
-                    except:
+                    except Exception:
                         continue
                     if prev is not None:
                         try:
                             prev.update(line_json)
                             line_json = prev
-                        except:
+                        except Exception:
                             pass
                     if args.target in line_json:
                         found.append(line_json)
@@ -133,7 +133,7 @@ def main(args, print_output):
                 if args.extract_prev:
                     try:
                         prev = json.loads(line)
-                    except:
+                    except Exception:
                         pass
             best = None
             if args.best:
@@ -198,7 +198,7 @@ def main(args, print_output):
                                 print(f)
                     try:
                         metric = found[-1][args.target] if not args.best or best is None else best[args.target]
-                    except:
+                    except Exception:
                         print(found[-1])
                         raise
                     if metric is not None:
@@ -247,7 +247,7 @@ def main(args, print_output):
             distinct_vals.update(v.keys())
         try:
             distinct_vals = {int(d) for d in distinct_vals}
-        except:
+        except Exception:
             print(distinct_vals)
             print()
             print("by_val", len(by_val))
@@ -269,7 +269,7 @@ def main(args, print_output):
                 vstr += '\t{}'.format(round(x, 5) if isinstance(x, float) else x)
                 try:
                     sums[mv].append(float(x))
-                except:
+                except Exception:
                     pass
             print('{}{}'.format(kstr[:args.key_len], vstr))
         if any(len(x) > 0 for x in sums.values()):

--- a/examples/data2vec/tasks/audio_classification.py
+++ b/examples/data2vec/tasks/audio_classification.py
@@ -114,7 +114,7 @@ class AudioClassificationTask(AudioPretrainingTask):
             # # AUC
             # try:
             #     auc = sklearn_metrics.roc_auc_score(target[:, k], output[:, k], average=None)
-            # except:
+            # except Exception:
             #     auc = 0
             #
             # # Precisions, recalls

--- a/examples/data2vec/tasks/image_classification.py
+++ b/examples/data2vec/tasks/image_classification.py
@@ -18,7 +18,7 @@ from fairseq.logging import metrics
 
 try:
     from ..data import ImageDataset
-except:
+except Exception:
     import sys
 
     sys.path.append("..")

--- a/examples/data2vec/tasks/image_pretraining.py
+++ b/examples/data2vec/tasks/image_pretraining.py
@@ -21,7 +21,7 @@ from fairseq.tasks import FairseqTask, register_task
 
 try:
     from ..data import ImageDataset
-except:
+except Exception:
     sys.path.append("..")
     from data import ImageDataset
 

--- a/examples/data2vec/tasks/mae_image_classification.py
+++ b/examples/data2vec/tasks/mae_image_classification.py
@@ -19,7 +19,7 @@ from fairseq.logging import metrics
 
 try:
     from ..data import MaeFinetuningImageDataset
-except:
+except Exception:
     sys.path.append("..")
     from data import MaeFinetuningImageDataset
 

--- a/examples/data2vec/tasks/mae_image_pretraining.py
+++ b/examples/data2vec/tasks/mae_image_pretraining.py
@@ -18,7 +18,7 @@ from fairseq.tasks import FairseqTask, register_task
 
 try:
     from ..data import MaeImageDataset
-except:
+except Exception:
     sys.path.append("..")
     from data import MaeImageDataset
 

--- a/examples/mms/lid/infer.py
+++ b/examples/mms/lid/infer.py
@@ -178,7 +178,7 @@ if __name__ == "__main__":
                 sample = utils.move_to_cuda(sample) if use_cuda else sample
                 try:
                     latent = model.forward_latent(**sample["net_input"])
-                except:
+                except Exception:
                     latent = None
                 logit = model.forward(**sample["net_input"])
                 logit_lsm = torch.log_softmax(logit.squeeze(), dim=-1)

--- a/examples/mms/lid_rerank/mms-zs/falign.py
+++ b/examples/mms/lid_rerank/mms-zs/falign.py
@@ -79,7 +79,7 @@ if __name__ == "__main__":
             try:
                 _, alphas, _ = falign_ext.falign(emissions, torch.tensor(token_sequence, device=device).int(), False)
                 aligned_alpha = max(alphas[-1]).item()
-            except:
+            except Exception:
                 aligned_alpha = math.log(0.000000001)
 
             with open(args.dst + "/uasr_score", "a") as f1:

--- a/examples/mms/lid_rerank/mms/run_single_lang.py
+++ b/examples/mms/lid_rerank/mms/run_single_lang.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
             hypos = fr.readlines()
             outputs = reorder_decode(hypos)
             fw.writelines([re.sub("\(\S+\)$", "", hypo).strip() + "\n" for ii,hypo in outputs])
-    except:
+    except Exception:
         print(f"Something went wrong with {lang}. If {lang} is not supported by the ASR model, then this is expected and OK. If it is supported, then something else has gone wrong unexpectedly.", file=sys.stderr)
         with open(dst + "/hypo.word.reord", "w") as fw:
             fw.writelines(["\n"] * len(open(dump+"/ids.txt", "r").readlines()))

--- a/examples/mms/lid_rerank/nllb/infer.py
+++ b/examples/mms/lid_rerank/nllb/infer.py
@@ -41,6 +41,6 @@ if __name__ == "__main__":
                 pred_langs = [x[0] for x in predictions]
                 idx = pred_langs.index(l)
                 score = math.log(predictions[idx][-1])
-            except:
+            except Exception:
                 score = -1000
             f.write(str(score) + "\n")

--- a/examples/speech_recognition/infer.py
+++ b/examples/speech_recognition/infer.py
@@ -47,7 +47,7 @@ output units",
             default=0.2,
             help="weight for lm while interpolating with neural score",
         )
-    except:
+    except Exception:
         pass
     parser.add_argument(
         "--rnnt_len_penalty", default=-0.5, help="rnnt length penalty on word level"
@@ -206,7 +206,7 @@ class ExistingEmissionsDecoder(object):
         ids = sample["id"].cpu().numpy()
         try:
             emissions = np.stack(self.emissions[ids])
-        except:
+        except Exception:
             print([x.shape for x in self.emissions[ids]])
             raise Exception("invalid sizes")
         emissions = torch.from_numpy(emissions)

--- a/examples/speech_recognition/kaldi/kaldi_decoder.py
+++ b/examples/speech_recognition/kaldi/kaldi_decoder.py
@@ -65,7 +65,7 @@ class KaldiDecoder(object):
             )
             from kaldi.lat.functions import DeterminizeLatticePhonePrunedOptions
             from kaldi.fstext import read_fst_kaldi, SymbolTable
-        except:
+        except Exception:
             warnings.warn(
                 "pykaldi is required for this functionality. Please install from https://github.com/pykaldi/pykaldi"
             )

--- a/examples/speech_recognition/w2l_decoder.py
+++ b/examples/speech_recognition/w2l_decoder.py
@@ -38,7 +38,7 @@ try:
         Trie,
         LexiconDecoder,
     )
-except:
+except Exception:
     warnings.warn(
         "flashlight python bindings are required to use this functionality. Please install from https://github.com/facebookresearch/flashlight/tree/master/bindings/python"
     )

--- a/examples/textless_nlp/gslm/ulm/sample.py
+++ b/examples/textless_nlp/gslm/ulm/sample.py
@@ -50,7 +50,7 @@ def main(args):
     try:
         from fairseq.dataclass.utils import convert_namespace_to_omegaconf
         args = convert_namespace_to_omegaconf(args)
-    except:
+    except Exception:
         pass
 
     # if args.max_tokens is None and args.max_sentences is None:

--- a/examples/wav2vec/unsupervised/scripts/g2p_wrd_to_phn.py
+++ b/examples/wav2vec/unsupervised/scripts/g2p_wrd_to_phn.py
@@ -36,7 +36,7 @@ def main():
             phones.extend(wrd_to_phn[w])
         try:
             print(" ".join(phones))
-        except:
+        except Exception:
             print(wrd_to_phn, words, phones, file=sys.stderr)
             raise
 

--- a/examples/wav2vec/unsupervised/scripts/wav2vec_apply_cluster_faiss.py
+++ b/examples/wav2vec/unsupervised/scripts/wav2vec_apply_cluster_faiss.py
@@ -70,7 +70,7 @@ def main():
 
     try:
         faiss_spec = parse_faiss_specs(spec.rstrip("/"))[0]
-    except:
+    except Exception:
         print(spec)
         raise
 

--- a/examples/wav2vec/unsupervised/tasks/unpaired_audio_text.py
+++ b/examples/wav2vec/unsupervised/tasks/unpaired_audio_text.py
@@ -268,7 +268,7 @@ class UnpairedAudioText(FairseqTask):
 
         try:
             world_size = get_data_parallel_world_size()
-        except:
+        except Exception:
             world_size = 1
 
         logging_output = {

--- a/examples/wav2vec/unsupervised/w2vu_generate.py
+++ b/examples/wav2vec/unsupervised/w2vu_generate.py
@@ -701,7 +701,7 @@ def cli_main():
         from hydra._internal.utils import get_args
 
         cfg_name = get_args().config_name or "config"
-    except:
+    except Exception:
         logger.warning("Failed to get config name from hydra args")
         cfg_name = "config"
 

--- a/examples/wav2vec/vq-wav2vec_featurize.py
+++ b/examples/wav2vec/vq-wav2vec_featurize.py
@@ -23,7 +23,7 @@ from torch.utils.data import DataLoader
 
 try:
     import tqdm
-except:
+except Exception:
     print("Install tqdm to use --log-format=tqdm")
 
 

--- a/examples/wav2vec/xlsr/scripts/gen_audio_embedding.py
+++ b/examples/wav2vec/xlsr/scripts/gen_audio_embedding.py
@@ -188,7 +188,7 @@ if __name__ == '__main__':
                 try:
                     latent = model.forward_latent(**sample['net_input'])
                     latents.append(latent.detach().cpu().numpy())
-                except:
+                except Exception:
                     latent = None
                 logit = model.forward(**sample['net_input'])
                 logits.append(logit.detach().cpu().numpy())

--- a/fairseq/data/audio/raw_audio_dataset.py
+++ b/fairseq/data/audio/raw_audio_dataset.py
@@ -286,7 +286,7 @@ class FileAudioDataset(RawAudioDataset):
             import pyarrow
 
             self.fnames = pyarrow.array(self.fnames)
-        except:
+        except Exception:
             logger.debug(
                 "Could not create a pyarrow array. Please install pyarrow for better performance"
             )

--- a/fairseq/data/encoders/gpt2_bpe_utils.py
+++ b/fairseq/data/encoders/gpt2_bpe_utils.py
@@ -91,7 +91,7 @@ class Encoder:
                     j = word.index(first, i)
                     new_word.extend(word[i:j])
                     i = j
-                except:
+                except Exception:
                     new_word.extend(word[i:])
                     break
 

--- a/fairseq/dataclass/utils.py
+++ b/fairseq/dataclass/utils.py
@@ -267,7 +267,7 @@ def _override_attr(
         ):
             try:
                 val = field_type(val)
-            except:
+            except Exception:
                 pass  # ignore errors here, they are often from interpolation args
 
         if val is None:
@@ -397,7 +397,7 @@ def convert_namespace_to_omegaconf(args: Namespace) -> DictConfig:
     with initialize(config_path=config_path):
         try:
             composed_cfg = compose("config", overrides=overrides, strict=False)
-        except:
+        except Exception:
             logger.error("Error when composing. Overrides: " + str(overrides))
             raise
 

--- a/fairseq/models/distributed_fairseq_model.py
+++ b/fairseq/models/distributed_fairseq_model.py
@@ -74,7 +74,7 @@ def DistributedFairseqModel(args, model, process_group, device):
                     DDPCommHookType,
                     register_ddp_comm_hook,
                 )
-            except:
+            except Exception:
                 logger.error(
                     "Could not import from torch.distributed.algorithms.ddp_comm_hooks; you may need to update your pytorch version"
                 )

--- a/fairseq/modules/fp32_batch_norm.py
+++ b/fairseq/modules/fp32_batch_norm.py
@@ -35,7 +35,7 @@ class Fp32BatchNorm(nn.Module):
                     try:
                         self.bn.weight = self.bn.weight.float()
                         self.bn.bias = self.bn.bias.float()
-                    except:
+                    except Exception:
                         self.bn.float()
             else:
                 self.bn.float()

--- a/fairseq_cli/generate.py
+++ b/fairseq_cli/generate.py
@@ -112,7 +112,7 @@ def _main(cfg: DictConfig, output_file):
             lms, _ = checkpoint_utils.load_model_ensemble(
                 [cfg.generation.lm_path], arg_overrides=overrides, task=None
             )
-        except:
+        except Exception:
             logger.warning(
                 f"Failed to load language model! Please make sure that the language model dict is the same "
                 f"as target dict and is located in the data dir ({cfg.task.data})"

--- a/fairseq_cli/hydra_train.py
+++ b/fairseq_cli/hydra_train.py
@@ -65,7 +65,7 @@ def _hydra_main(cfg: FairseqConfig, **kwargs) -> float:
         best_val = metrics.get_smoothed_value(
             "valid", cfg.checkpoint.best_checkpoint_metric
         )
-    except:
+    except Exception:
         best_val = None
 
     if best_val is None:
@@ -79,7 +79,7 @@ def cli_main():
         from hydra._internal.utils import get_args
 
         cfg_name = get_args().config_name or "config"
-    except:
+    except Exception:
         logger.warning("Failed to get config name from hydra args")
         cfg_name = "config"
 

--- a/fairseq_cli/hydra_validate.py
+++ b/fairseq_cli/hydra_validate.py
@@ -176,7 +176,7 @@ def cli_main():
         from hydra._internal.utils import get_args
 
         cfg_name = get_args().config_name or "config"
-    except:
+    except Exception:
         logger.warning("Failed to get config name from hydra args")
         cfg_name = "config"
 


### PR DESCRIPTION
## What
Replace 40 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors.